### PR TITLE
Fix permissions errors when running fundraising migrations

### DIFF
--- a/live/stage/data-stores/postgres/setup/dependencies.tf
+++ b/live/stage/data-stores/postgres/setup/dependencies.tf
@@ -26,4 +26,18 @@ locals {
   master_db_pass                  = data.aws_ssm_parameter.master_db_pass.value
   master_db_name                  = data.terraform_remote_state.postgres.outputs.db_name
   master_db_port                  = data.terraform_remote_state.postgres.outputs.db_port
+  table_privileges = [
+    "DELETE",
+    "INSERT",
+    "REFERENCES",
+    "SELECT",
+    "TRIGGER",
+    "TRUNCATE",
+    "UPDATE"
+  ]
+  sequence_privileges = [
+    "SELECT",
+    "UPDATE",
+    "USAGE"
+  ]
 }

--- a/live/stage/data-stores/postgres/setup/fundraising.tf
+++ b/live/stage/data-stores/postgres/setup/fundraising.tf
@@ -26,33 +26,36 @@ resource "aws_ssm_parameter" "fundraising_db_pass" {
 
 // Create postgres role and db
 resource "postgresql_role" "fundraising" {
-  name                = aws_ssm_parameter.fundraising_db_user.value
-  login               = true
-  password            = aws_ssm_parameter.fundraising_db_pass.value
-  skip_reassign_owned = true
+  name     = aws_ssm_parameter.fundraising_db_user.value
+  login    = true
+  password = aws_ssm_parameter.fundraising_db_pass.value
+  roles    = [local.master_db_user]
 }
 
 resource "postgresql_database" "fundraising" {
-  name  = "fundraising_${local.environment}"
-  owner = local.master_db_user
+  name       = "fundraising_${local.environment}"
+  owner      = local.master_db_user
+  lc_collate = "en_US.UTF-8"
+  lc_ctype   = "en_US.UTF-8"
+  encoding   = "UTF8"
 }
 
 resource "postgresql_default_privileges" "fundraising_tables" {
-  role     = postgresql_role.fundraising.name
-  database = postgresql_database.fundraising.name
-  schema   = "public"
-
-  owner       = local.master_db_user
+  database    = postgresql_database.fundraising.name
+  depends_on  = ["postgresql_database.fundraising", "postgresql_role.fundraising"]
   object_type = "table"
+  owner       = local.master_db_user
   privileges  = ["ALL"]
+  role        = postgresql_role.fundraising.name
+  schema      = "public"
 }
 
 resource "postgresql_default_privileges" "fundraising_sequence" {
-  role     = postgresql_role.fundraising.name
-  database = postgresql_database.fundraising.name
-  schema   = "public"
-
-  owner       = local.master_db_user
+  database    = postgresql_database.fundraising.name
+  depends_on  = ["postgresql_database.fundraising", "postgresql_role.fundraising"]
   object_type = "sequence"
+  owner       = local.master_db_user
   privileges  = ["ALL"]
+  role        = postgresql_role.fundraising.name
+  schema      = "public"
 }

--- a/live/stage/data-stores/postgres/setup/fundraising.tf
+++ b/live/stage/data-stores/postgres/setup/fundraising.tf
@@ -26,8 +26,8 @@ resource "aws_ssm_parameter" "fundraising_db_pass" {
 
 // Create postgres role and db
 resource "postgresql_role" "fundraising" {
-  name     = aws_ssm_parameter.fundraising_db_user.value
   login    = true
+  name     = aws_ssm_parameter.fundraising_db_user.value
   password = aws_ssm_parameter.fundraising_db_pass.value
   roles    = [local.master_db_user]
 }
@@ -45,7 +45,7 @@ resource "postgresql_default_privileges" "fundraising_tables" {
   depends_on  = ["postgresql_database.fundraising", "postgresql_role.fundraising"]
   object_type = "table"
   owner       = local.master_db_user
-  privileges  = ["ALL"]
+  privileges  = local.table_privileges
   role        = postgresql_role.fundraising.name
   schema      = "public"
 }
@@ -55,7 +55,7 @@ resource "postgresql_default_privileges" "fundraising_sequence" {
   depends_on  = ["postgresql_database.fundraising", "postgresql_role.fundraising"]
   object_type = "sequence"
   owner       = local.master_db_user
-  privileges  = ["ALL"]
+  privileges  = local.sequence_privileges
   role        = postgresql_role.fundraising.name
   schema      = "public"
 }

--- a/live/stage/data-stores/postgres/setup/fundraising.tf
+++ b/live/stage/data-stores/postgres/setup/fundraising.tf
@@ -34,13 +34,25 @@ resource "postgresql_role" "fundraising" {
 
 resource "postgresql_database" "fundraising" {
   name  = "fundraising_${local.environment}"
-  owner = aws_ssm_parameter.fundraising_db_user.value
+  owner = local.master_db_user
 }
 
-resource postgresql_grant "fundraising" {
-  database    = postgresql_database.fundraising.name
-  role        = postgresql_role.fundraising.name
-  schema      = "public"
+resource "postgresql_default_privileges" "fundraising_tables" {
+  role     = postgresql_role.fundraising.name
+  database = postgresql_database.fundraising.name
+  schema   = "public"
+
+  owner       = local.master_db_user
   object_type = "table"
+  privileges  = ["ALL"]
+}
+
+resource "postgresql_default_privileges" "fundraising_sequence" {
+  role     = postgresql_role.fundraising.name
+  database = postgresql_database.fundraising.name
+  schema   = "public"
+
+  owner       = local.master_db_user
+  object_type = "sequence"
   privileges  = ["ALL"]
 }

--- a/live/stage/data-stores/redis/main.tf
+++ b/live/stage/data-stores/redis/main.tf
@@ -31,8 +31,8 @@ module "redis" {
   instance_type               = "cache.t2.micro"
   engine_version              = "4.0.10"
   alarm_cpu_threshold_percent = 90
-  # https://github.com/cloudposse/terraform-aws-elasticache-redis/pull/42#issuecomment-525342971
-  auth_token         = null
-  availability_zones = data.aws_availability_zones.available.names
-  automatic_failover = false
+  transit_encryption_enabled  = false
+  auth_token                  = null
+  availability_zones          = data.aws_availability_zones.available.names
+  automatic_failover          = false
 }

--- a/live/stage/services/fundraising/dependencies.tf
+++ b/live/stage/services/fundraising/dependencies.tf
@@ -76,7 +76,7 @@ locals {
   redis_host   = data.terraform_remote_state.redis.outputs.host
   redis_port   = data.terraform_remote_state.redis.outputs.port
   database_url = "postgres://${local.db_user}:${urlencode(local.db_pass)}@${local.db_address}:${local.db_port}/${local.db_name}"
-  redis_url    = "redis://${local.redis_host}:${local.redis_port}"
+  redis_url    = "redis://${local.redis_host}:${local.redis_port}/0"
 
   acm_certificate_domain                = "*.debtcollective.org"
   ec2_security_group_id                 = data.terraform_remote_state.vpc.outputs.ec2_security_group_id
@@ -91,5 +91,4 @@ locals {
   subnet_ids                            = data.terraform_remote_state.vpc.outputs.public_subnet_ids
   vpc_id                                = data.terraform_remote_state.vpc.outputs.vpc_id
   vpc_remote_state_workspace            = "stage-network"
-  vpc_security_group_ids                = [data.terraform_remote_state.vpc.outputs.rds_security_group_id]
 }

--- a/live/stage/services/fundraising/main.tf
+++ b/live/stage/services/fundraising/main.tf
@@ -23,17 +23,16 @@ module "fundraising" {
   source      = "../../../../modules/services/fundraising"
   environment = local.environment
 
-  database_url = local.database_url
-  redis_url    = local.redis_url
-
-  acm_certificate_domain = local.acm_certificate_domain
-  elb_security_groups    = [local.elb_security_group_id]
-  vpc_id                 = local.vpc_id
-
+  acm_certificate_domain  = local.acm_certificate_domain
+  elb_security_groups     = [local.elb_security_group_id]
+  vpc_id                  = local.vpc_id
   key_name                = local.ssh_key_pair_name
   iam_instance_profile_id = local.iam_instance_profile_id
   subnet_ids              = local.subnet_ids
   security_groups         = [local.ec2_security_group_id]
+
+  database_url = local.database_url
+  redis_url    = local.redis_url
 }
 
 data "aws_route53_zone" "primary" {

--- a/modules/services/fundraising/container_definitions.tf
+++ b/modules/services/fundraising/container_definitions.tf
@@ -48,6 +48,10 @@ module "container_definitions" {
       name  = "REDIS_URL",
       value = var.redis_url
     },
+    {
+      name  = "PORT",
+      value = local.container_port
+    }
   ]
 
   port_mappings = [


### PR DESCRIPTION
**What:** Fix permissions errors when running fundraising migrations

**Why:** Migrations were failing due permissions. I recreated the database and ran the migrations again with updated credentials and these are working now.

Related to https://github.com/debtcollective/fundraising/issues/90

**How:**

- Update postgres credentials for fundraising and disputes_api