### PR TITLE
add cookie-based SSO config for fundraising

### DIFF
--- a/live/stage/services/fundraising/dependencies.tf
+++ b/live/stage/services/fundraising/dependencies.tf
@@ -67,16 +67,26 @@ data "aws_ssm_parameter" "db_pass" {
   name = data.terraform_remote_state.postgres_setup.outputs.fundraising_db_pass_ssm_key
 }
 
+// hard coded until we migrate Discourse to this repo
+data "aws_ssm_parameter" "discourse_sso_jwt_secret" {
+  name = "/production/services/discourse/sso_jwt_secret"
+}
+
 locals {
-  db_user      = data.aws_ssm_parameter.db_user.value
-  db_pass      = data.aws_ssm_parameter.db_pass.value
-  db_address   = data.terraform_remote_state.postgres.outputs.db_address
-  db_port      = data.terraform_remote_state.postgres.outputs.db_port
-  db_name      = data.terraform_remote_state.postgres_setup.outputs.fundraising_db_name
-  redis_host   = data.terraform_remote_state.redis.outputs.host
-  redis_port   = data.terraform_remote_state.redis.outputs.port
-  database_url = "postgres://${local.db_user}:${urlencode(local.db_pass)}@${local.db_address}:${local.db_port}/${local.db_name}"
-  redis_url    = "redis://${local.redis_host}:${local.redis_port}/0"
+  database_url         = "postgres://${local.db_user}:${urlencode(local.db_pass)}@${local.db_address}:${local.db_port}/${local.db_name}"
+  db_address           = data.terraform_remote_state.postgres.outputs.db_address
+  db_name              = data.terraform_remote_state.postgres_setup.outputs.fundraising_db_name
+  db_pass              = data.aws_ssm_parameter.db_pass.value
+  db_port              = data.terraform_remote_state.postgres.outputs.db_port
+  db_user              = data.aws_ssm_parameter.db_user.value
+  discourse_login_url  = "${local.discourse_uri}/session/sso_cookies"
+  discourse_signup_url = "${local.discourse_uri}/session/sso_cookies/signup"
+  discourse_uri        = "https://community.debtcollective.org"
+  redis_host           = data.terraform_remote_state.redis.outputs.host
+  redis_port           = data.terraform_remote_state.redis.outputs.port
+  redis_url            = "redis://${local.redis_host}:${local.redis_port}/0"
+  sso_cookie_name      = "tdc_auth_production"
+  sso_jwt_secret       = data.aws_ssm_parameter.discourse_sso_jwt_secret.value
 
   acm_certificate_domain                = "*.debtcollective.org"
   ec2_security_group_id                 = data.terraform_remote_state.vpc.outputs.ec2_security_group_id

--- a/live/stage/services/fundraising/main.tf
+++ b/live/stage/services/fundraising/main.tf
@@ -31,8 +31,12 @@ module "fundraising" {
   subnet_ids              = local.subnet_ids
   security_groups         = [local.ec2_security_group_id]
 
-  database_url = local.database_url
-  redis_url    = local.redis_url
+  database_url         = local.database_url
+  discourse_login_url  = local.discourse_login_url
+  discourse_signup_url = local.discourse_signup_url
+  redis_url            = local.redis_url
+  sso_cookie_name      = local.sso_cookie_name
+  sso_jwt_secret       = local.sso_jwt_secret
 }
 
 data "aws_route53_zone" "primary" {

--- a/modules/services/fundraising/container_definitions.tf
+++ b/modules/services/fundraising/container_definitions.tf
@@ -41,12 +41,28 @@ module "container_definitions" {
       value = var.database_url
     },
     {
+      name  = "DISCOURSE_LOGIN_URL",
+      value = var.discourse_login_url
+    },
+    {
+      name  = "DISCOURSE_SIGNUP_URL",
+      value = var.discourse_signup_url
+    },
+    {
       name  = "SECRET_KEY_BASE",
       value = random_string.secret_key_base.result
     },
     {
       name  = "REDIS_URL",
       value = var.redis_url
+    },
+    {
+      name  = "SSO_COOKIE_NAME",
+      value = var.sso_cookie_name
+    },
+    {
+      name  = "SSO_JWT_SECRET",
+      value = var.sso_jwt_secret
     },
     {
       name  = "PORT",

--- a/modules/services/fundraising/vars.tf
+++ b/modules/services/fundraising/vars.tf
@@ -66,3 +66,19 @@ variable "database_url" {
 variable "redis_url" {
   description = "Redis URL used for cache and Sidekiq"
 }
+
+variable "sso_cookie_name" {
+  description = "SSO cookie name as defined in Discourse"
+}
+
+variable "sso_jwt_secret" {
+  description = "SSO JWT secret as defined in Discourse"
+}
+
+variable "discourse_login_url" {
+  description = "SSO login URL"
+}
+
+variable "discourse_signup_url" {
+  description = "SSO signup URL"
+}


### PR DESCRIPTION
**What:** add cookie-based SSO config fundraising

**Why:** To be able to authenticate in stage with production accounts. Related to https://github.com/debtcollective/ds-terraform/pull/22

**How:**

- Add variables to ECS container definitions
- Use vars from Discourse production