### PR TITLE
Refactor services to run in one cluster per environment

### DIFF
--- a/live/stage/services/cluster/dependencies.tf
+++ b/live/stage/services/cluster/dependencies.tf
@@ -1,3 +1,15 @@
+data "terraform_remote_state" "iam" {
+  backend = "remote"
+
+  config = {
+    organization = local.remote_state_organization
+
+    workspaces = {
+      name = local.iam_remote_state_workspace
+    }
+  }
+}
+
 data "terraform_remote_state" "vpc" {
   backend = "remote"
 
@@ -11,9 +23,18 @@ data "terraform_remote_state" "vpc" {
 }
 
 locals {
-  remote_state_organization  = "debtcollective"
-  vpc_remote_state_workspace = "stage-network"
+  environment = "stage"
 
-  security_group_ids = [data.terraform_remote_state.vpc.outputs.elb_security_group_id]
-  subnet_ids         = data.terraform_remote_state.vpc.outputs.public_subnet_ids
+  ec2_security_group_ids  = [data.terraform_remote_state.vpc.outputs.ec2_security_group_id]
+  elb_security_group_ids  = [data.terraform_remote_state.vpc.outputs.elb_security_group_id]
+  iam_instance_profile_id = data.terraform_remote_state.iam.outputs.instance_profile_id
+  instance_type           = "t3a.nano"
+  key_name                = data.terraform_remote_state.vpc.outputs.ssh_key_pair_name
+  subnet_ids              = data.terraform_remote_state.vpc.outputs.public_subnet_ids
+  vpc_id                  = data.terraform_remote_state.vpc.outputs.vpc_id
+
+  iam_remote_state_workspace = "global-iam"
+  remote_state_organization  = "debtcollective"
+  vpc_remote_state_workspace = "${local.environment}-network"
+
 }

--- a/live/stage/services/cluster/dependencies.tf
+++ b/live/stage/services/cluster/dependencies.tf
@@ -1,0 +1,19 @@
+data "terraform_remote_state" "vpc" {
+  backend = "remote"
+
+  config = {
+    organization = local.remote_state_organization
+
+    workspaces = {
+      name = local.vpc_remote_state_workspace
+    }
+  }
+}
+
+locals {
+  remote_state_organization  = "debtcollective"
+  vpc_remote_state_workspace = "stage-network"
+
+  security_group_ids = [data.terraform_remote_state.vpc.outputs.elb_security_group_id]
+  subnet_ids         = data.terraform_remote_state.vpc.outputs.public_subnet_ids
+}

--- a/live/stage/services/cluster/main.tf
+++ b/live/stage/services/cluster/main.tf
@@ -1,0 +1,28 @@
+terraform {
+  required_version = ">=0.12.13"
+
+  backend "remote" {
+    hostname     = "app.terraform.io"
+    organization = "debtcollective"
+
+    workspaces {
+      name = "stage-cluster"
+    }
+  }
+}
+
+provider "aws" {
+  version = "~> 2.0"
+}
+
+locals {
+  environment = "stage"
+}
+
+module "cluster" {
+  source      = "../../../../modules/services/cluster"
+  environment = local.environment
+
+  security_group_ids = local.security_group_ids
+  subnet_ids         = local.subnet_ids
+}

--- a/live/stage/services/cluster/main.tf
+++ b/live/stage/services/cluster/main.tf
@@ -15,15 +15,32 @@ provider "aws" {
   version = "~> 2.0"
 }
 
-locals {
-  environment = "stage"
-}
-
 module "cluster" {
   source      = "../../../../modules/services/cluster"
   environment = local.environment
 
   acm_certificate_domain = "*.debtcollective.org"
-  security_group_ids     = local.security_group_ids
+  security_group_ids     = local.elb_security_group_ids
   subnet_ids             = local.subnet_ids
+}
+
+// Autoscaling and launch configurations for this cluster
+module "autoscaling" {
+  source      = "../../../../modules/utils/autoscaling"
+  environment = local.environment
+
+  cluster_name            = module.cluster.ecs_cluster_name
+  iam_instance_profile_id = local.iam_instance_profile_id
+  instance_type           = local.instance_type
+  key_name                = local.key_name
+  security_groups         = local.ec2_security_group_ids
+  subnet_ids              = local.subnet_ids
+
+  tags = [
+    {
+      key                 = "Name"
+      value               = "${local.environment}_instance"
+      propagate_at_launch = true
+    },
+  ]
 }

--- a/live/stage/services/cluster/main.tf
+++ b/live/stage/services/cluster/main.tf
@@ -23,6 +23,7 @@ module "cluster" {
   source      = "../../../../modules/services/cluster"
   environment = local.environment
 
-  security_group_ids = local.security_group_ids
-  subnet_ids         = local.subnet_ids
+  acm_certificate_domain = "*.debtcollective.org"
+  security_group_ids     = local.security_group_ids
+  subnet_ids             = local.subnet_ids
 }

--- a/live/stage/services/cluster/outputs.tf
+++ b/live/stage/services/cluster/outputs.tf
@@ -1,0 +1,24 @@
+output "lb_id" {
+  description = "ALB id"
+  value       = module.cluster.lb_id
+}
+
+output "lb_arn_suffix" {
+  description = "ALB arn suffix for use with CloudWatch Metrics"
+  value       = module.cluster.lb_arn_suffix
+}
+
+output "lb_dns_name" {
+  description = "ALB DNS name"
+  value       = module.cluster.lb_dns_name
+}
+
+output "lb_zone_id" {
+  description = "ALB canonical hosted zone ID, to be used in a Route 53 Alias record"
+  value       = module.cluster.lb_zone_id
+}
+
+output "cluster_id" {
+  description = "ECS cluster ID/ARN"
+  value       = module.cluster.cluster_id
+}

--- a/live/stage/services/cluster/outputs.tf
+++ b/live/stage/services/cluster/outputs.tf
@@ -18,7 +18,17 @@ output "lb_zone_id" {
   value       = module.cluster.lb_zone_id
 }
 
-output "cluster_id" {
+output "lb_listener_id" {
+  description = "ALB HTTPS listener id"
+  value       = module.cluster.lb_listener_id
+}
+
+output "ecs_cluster_id" {
   description = "ECS cluster ID/ARN"
-  value       = module.cluster.cluster_id
+  value       = module.cluster.ecs_cluster_id
+}
+
+output "ecs_cluster_name" {
+  description = "ECS cluster name"
+  value       = module.cluster.ecs_cluster_name
 }

--- a/live/stage/services/disputes_api/dependencies.tf
+++ b/live/stage/services/disputes_api/dependencies.tf
@@ -57,21 +57,20 @@ data "aws_ssm_parameter" "db_pass" {
 locals {
   environment = "stage"
 
-  db_address     = data.terraform_remote_state.postgres.outputs.db_address
-  db_name        = data.terraform_remote_state.postgres_setup.outputs.disputes_api_db_name
-  db_pass        = data.aws_ssm_parameter.db_pass.value
-  db_port        = data.terraform_remote_state.postgres.outputs.db_port
-  db_user        = data.aws_ssm_parameter.db_user.value
+  db_address    = data.terraform_remote_state.postgres.outputs.db_address
+  db_name       = data.terraform_remote_state.postgres_setup.outputs.disputes_api_db_name
+  db_pass       = data.aws_ssm_parameter.db_pass.value
+  db_port       = data.terraform_remote_state.postgres.outputs.db_port
+  db_user       = data.aws_ssm_parameter.db_user.value
+  database_url  = "postgres://${local.db_user}:${urlencode(local.db_pass)}@${local.db_address}:${local.db_port}/${local.db_name}"
+  introspection = true
+
   ecs_cluster_id = data.terraform_remote_state.cluster.outputs.ecs_cluster_id
   lb_dns_name    = data.terraform_remote_state.cluster.outputs.lb_dns_name
   lb_listener_id = data.terraform_remote_state.cluster.outputs.lb_listener_id
   lb_zone_id     = data.terraform_remote_state.cluster.outputs.lb_zone_id
   vpc_id         = data.terraform_remote_state.vpc.outputs.vpc_id
 
-  database_url  = "postgres://${local.db_user}:${urlencode(local.db_pass)}@${local.db_address}:${local.db_port}/${local.db_name}"
-  introspection = true
-
-  acm_certificate_domain                = "*.debtcollective.org"
   cluster_remote_state_workspace        = "${local.environment}-cluster"
   iam_remote_state_workspace            = "global-iam"
   postgres_remote_state_workspace       = "${local.environment}-postgres"

--- a/live/stage/services/disputes_api/dependencies.tf
+++ b/live/stage/services/disputes_api/dependencies.tf
@@ -1,3 +1,15 @@
+data "terraform_remote_state" "iam" {
+  backend = "remote"
+
+  config = {
+    organization = local.remote_state_organization
+
+    workspaces = {
+      name = local.iam_remote_state_workspace
+    }
+  }
+}
+
 data "terraform_remote_state" "vpc" {
   backend = "remote"
 
@@ -10,14 +22,14 @@ data "terraform_remote_state" "vpc" {
   }
 }
 
-data "terraform_remote_state" "iam" {
+data "terraform_remote_state" "cluster" {
   backend = "remote"
 
   config = {
     organization = local.remote_state_organization
 
     workspaces = {
-      name = local.iam_remote_state_workspace
+      name = local.cluster_remote_state_workspace
     }
   }
 }
@@ -55,25 +67,33 @@ data "aws_ssm_parameter" "db_pass" {
 }
 
 locals {
-  db_user       = data.aws_ssm_parameter.db_user.value
-  db_pass       = data.aws_ssm_parameter.db_pass.value
-  db_address    = data.terraform_remote_state.postgres.outputs.db_address
-  db_port       = data.terraform_remote_state.postgres.outputs.db_port
-  db_name       = data.terraform_remote_state.postgres_setup.outputs.disputes_api_db_name
-  database_url  = "postgres://${local.db_user}:${urlencode(local.db_pass)}@${local.db_address}:${local.db_port}/${local.db_name}"
-  introspection = true
+  environment = "stage"
+
+  database_url            = "postgres://${local.db_user}:${urlencode(local.db_pass)}@${local.db_address}:${local.db_port}/${local.db_name}"
+  db_address              = data.terraform_remote_state.postgres.outputs.db_address
+  db_name                 = data.terraform_remote_state.postgres_setup.outputs.disputes_api_db_name
+  db_pass                 = data.aws_ssm_parameter.db_pass.value
+  db_port                 = data.terraform_remote_state.postgres.outputs.db_port
+  db_user                 = data.aws_ssm_parameter.db_user.value
+  lb_dns_name             = data.terraform_remote_state.cluster.outputs.lb_dns_name
+  ec2_security_group_id   = data.terraform_remote_state.vpc.outputs.ec2_security_group_id
+  ecs_cluster_id          = data.terraform_remote_state.cluster.outputs.ecs_cluster_id
+  ecs_cluster_name        = data.terraform_remote_state.cluster.outputs.ecs_cluster_name
+  elb_security_group_id   = data.terraform_remote_state.vpc.outputs.elb_security_group_id
+  iam_instance_profile_id = data.terraform_remote_state.iam.outputs.instance_profile_id
+  introspection           = true
+  lb_listener_id          = data.terraform_remote_state.cluster.outputs.lb_listener_id
+  ssh_key_pair_name       = data.terraform_remote_state.vpc.outputs.ssh_key_pair_name
+  subnet_ids              = data.terraform_remote_state.vpc.outputs.public_subnet_ids
+  vpc_id                  = data.terraform_remote_state.vpc.outputs.vpc_id
+  vpc_security_group_ids  = [data.terraform_remote_state.vpc.outputs.rds_security_group_id]
+  lb_zone_id              = data.terraform_remote_state.cluster.outputs.lb_zone_id
 
   acm_certificate_domain                = "*.debtcollective.org"
-  ec2_security_group_id                 = data.terraform_remote_state.vpc.outputs.ec2_security_group_id
-  elb_security_group_id                 = data.terraform_remote_state.vpc.outputs.elb_security_group_id
-  iam_instance_profile_id               = data.terraform_remote_state.iam.outputs.instance_profile_id
-  ssh_key_pair_name                     = data.terraform_remote_state.vpc.outputs.ssh_key_pair_name
-  subnet_ids                            = data.terraform_remote_state.vpc.outputs.public_subnet_ids
-  vpc_id                                = data.terraform_remote_state.vpc.outputs.vpc_id
-  vpc_security_group_ids                = [data.terraform_remote_state.vpc.outputs.rds_security_group_id]
-  postgres_remote_state_workspace       = "stage-postgres"
-  postgres_setup_remote_state_workspace = "stage-postgres-setup"
-  remote_state_organization             = "debtcollective"
+  cluster_remote_state_workspace        = "${local.environment}-cluster"
   iam_remote_state_workspace            = "global-iam"
-  vpc_remote_state_workspace            = "stage-network"
+  postgres_remote_state_workspace       = "${local.environment}-postgres"
+  postgres_setup_remote_state_workspace = "${local.environment}-postgres-setup"
+  remote_state_organization             = "debtcollective"
+  vpc_remote_state_workspace            = "${local.environment}-network"
 }

--- a/live/stage/services/disputes_api/dependencies.tf
+++ b/live/stage/services/disputes_api/dependencies.tf
@@ -1,15 +1,3 @@
-data "terraform_remote_state" "iam" {
-  backend = "remote"
-
-  config = {
-    organization = local.remote_state_organization
-
-    workspaces = {
-      name = local.iam_remote_state_workspace
-    }
-  }
-}
-
 data "terraform_remote_state" "vpc" {
   backend = "remote"
 
@@ -69,25 +57,19 @@ data "aws_ssm_parameter" "db_pass" {
 locals {
   environment = "stage"
 
-  database_url            = "postgres://${local.db_user}:${urlencode(local.db_pass)}@${local.db_address}:${local.db_port}/${local.db_name}"
-  db_address              = data.terraform_remote_state.postgres.outputs.db_address
-  db_name                 = data.terraform_remote_state.postgres_setup.outputs.disputes_api_db_name
-  db_pass                 = data.aws_ssm_parameter.db_pass.value
-  db_port                 = data.terraform_remote_state.postgres.outputs.db_port
-  db_user                 = data.aws_ssm_parameter.db_user.value
-  lb_dns_name             = data.terraform_remote_state.cluster.outputs.lb_dns_name
-  ec2_security_group_id   = data.terraform_remote_state.vpc.outputs.ec2_security_group_id
-  ecs_cluster_id          = data.terraform_remote_state.cluster.outputs.ecs_cluster_id
-  ecs_cluster_name        = data.terraform_remote_state.cluster.outputs.ecs_cluster_name
-  elb_security_group_id   = data.terraform_remote_state.vpc.outputs.elb_security_group_id
-  iam_instance_profile_id = data.terraform_remote_state.iam.outputs.instance_profile_id
-  introspection           = true
-  lb_listener_id          = data.terraform_remote_state.cluster.outputs.lb_listener_id
-  ssh_key_pair_name       = data.terraform_remote_state.vpc.outputs.ssh_key_pair_name
-  subnet_ids              = data.terraform_remote_state.vpc.outputs.public_subnet_ids
-  vpc_id                  = data.terraform_remote_state.vpc.outputs.vpc_id
-  vpc_security_group_ids  = [data.terraform_remote_state.vpc.outputs.rds_security_group_id]
-  lb_zone_id              = data.terraform_remote_state.cluster.outputs.lb_zone_id
+  db_address     = data.terraform_remote_state.postgres.outputs.db_address
+  db_name        = data.terraform_remote_state.postgres_setup.outputs.disputes_api_db_name
+  db_pass        = data.aws_ssm_parameter.db_pass.value
+  db_port        = data.terraform_remote_state.postgres.outputs.db_port
+  db_user        = data.aws_ssm_parameter.db_user.value
+  ecs_cluster_id = data.terraform_remote_state.cluster.outputs.ecs_cluster_id
+  lb_dns_name    = data.terraform_remote_state.cluster.outputs.lb_dns_name
+  lb_listener_id = data.terraform_remote_state.cluster.outputs.lb_listener_id
+  lb_zone_id     = data.terraform_remote_state.cluster.outputs.lb_zone_id
+  vpc_id         = data.terraform_remote_state.vpc.outputs.vpc_id
+
+  database_url  = "postgres://${local.db_user}:${urlencode(local.db_pass)}@${local.db_address}:${local.db_port}/${local.db_name}"
+  introspection = true
 
   acm_certificate_domain                = "*.debtcollective.org"
   cluster_remote_state_workspace        = "${local.environment}-cluster"

--- a/live/stage/services/disputes_api/main.tf
+++ b/live/stage/services/disputes_api/main.tf
@@ -35,15 +35,10 @@ module "disputes_api" {
   source      = "../../../../modules/services/disputes_api"
   environment = local.environment
 
-  vpc_id                  = local.vpc_id
-  lb_listener_id          = local.lb_listener_id
-  ecs_cluster_id          = local.ecs_cluster_id
-  ecs_cluster_name        = local.ecs_cluster_name
-  key_name                = local.ssh_key_pair_name
-  iam_instance_profile_id = local.iam_instance_profile_id
-  subnet_ids              = local.subnet_ids
-  security_groups         = [local.ec2_security_group_id]
-  domain                  = aws_route53_record.disputes_api.fqdn
+  domain         = aws_route53_record.disputes_api.fqdn
+  ecs_cluster_id = local.ecs_cluster_id
+  lb_listener_id = local.lb_listener_id
+  vpc_id         = local.vpc_id
 
   database_url  = local.database_url
   introspection = local.introspection

--- a/live/stage/services/disputes_api/main.tf
+++ b/live/stage/services/disputes_api/main.tf
@@ -15,26 +15,6 @@ provider "aws" {
   version = "~> 2.0"
 }
 
-locals {
-  environment = "stage"
-}
-
-module "disputes_api" {
-  source      = "../../../../modules/services/disputes_api"
-  environment = local.environment
-
-  acm_certificate_domain  = local.acm_certificate_domain
-  elb_security_groups     = [local.elb_security_group_id]
-  vpc_id                  = local.vpc_id
-  key_name                = local.ssh_key_pair_name
-  iam_instance_profile_id = local.iam_instance_profile_id
-  subnet_ids              = local.subnet_ids
-  security_groups         = [local.ec2_security_group_id]
-
-  database_url  = local.database_url
-  introspection = local.introspection
-}
-
 data "aws_route53_zone" "primary" {
   name = "debtcollective.org"
 }
@@ -45,8 +25,26 @@ resource "aws_route53_record" "disputes_api" {
   type    = "A"
 
   alias {
-    name                   = module.disputes_api.dns_name
-    zone_id                = module.disputes_api.zone_id
+    name                   = local.lb_dns_name
+    zone_id                = local.lb_zone_id
     evaluate_target_health = true
   }
+}
+
+module "disputes_api" {
+  source      = "../../../../modules/services/disputes_api"
+  environment = local.environment
+
+  vpc_id                  = local.vpc_id
+  lb_listener_id          = local.lb_listener_id
+  ecs_cluster_id          = local.ecs_cluster_id
+  ecs_cluster_name        = local.ecs_cluster_name
+  key_name                = local.ssh_key_pair_name
+  iam_instance_profile_id = local.iam_instance_profile_id
+  subnet_ids              = local.subnet_ids
+  security_groups         = [local.ec2_security_group_id]
+  domain                  = aws_route53_record.disputes_api.fqdn
+
+  database_url  = local.database_url
+  introspection = local.introspection
 }

--- a/live/stage/services/disputes_api/outputs.tf
+++ b/live/stage/services/disputes_api/outputs.tf
@@ -1,14 +1,4 @@
 output "service_name" {
-  value       = "${module.disputes_api.service_name}"
+  value       = module.disputes_api.service_name
   description = "ECS Service name"
-}
-
-output "dns_name" {
-  value       = "${module.disputes_api.dns_name}"
-  description = "ELB dns_name"
-}
-
-output "zone_id" {
-  value       = "${module.disputes_api.zone_id}"
-  description = "ELB zone_id"
 }

--- a/live/stage/services/fundraising/main.tf
+++ b/live/stage/services/fundraising/main.tf
@@ -15,30 +15,6 @@ provider "aws" {
   version = "~> 2.0"
 }
 
-locals {
-  environment = "stage"
-}
-
-module "fundraising" {
-  source      = "../../../../modules/services/fundraising"
-  environment = local.environment
-
-  acm_certificate_domain  = local.acm_certificate_domain
-  elb_security_groups     = [local.elb_security_group_id]
-  vpc_id                  = local.vpc_id
-  key_name                = local.ssh_key_pair_name
-  iam_instance_profile_id = local.iam_instance_profile_id
-  subnet_ids              = local.subnet_ids
-  security_groups         = [local.ec2_security_group_id]
-
-  database_url         = local.database_url
-  discourse_login_url  = local.discourse_login_url
-  discourse_signup_url = local.discourse_signup_url
-  redis_url            = local.redis_url
-  sso_cookie_name      = local.sso_cookie_name
-  sso_jwt_secret       = local.sso_jwt_secret
-}
-
 data "aws_route53_zone" "primary" {
   name = "debtcollective.org"
 }
@@ -49,8 +25,25 @@ resource "aws_route53_record" "fundraising" {
   type    = "A"
 
   alias {
-    name                   = module.fundraising.dns_name
-    zone_id                = module.fundraising.zone_id
+    name                   = local.lb_dns_name
+    zone_id                = local.lb_zone_id
     evaluate_target_health = true
   }
+}
+
+module "fundraising" {
+  source      = "../../../../modules/services/fundraising"
+  environment = local.environment
+
+  domain         = aws_route53_record.fundraising.fqdn
+  ecs_cluster_id = local.ecs_cluster_id
+  lb_listener_id = local.lb_listener_id
+  vpc_id         = local.vpc_id
+
+  database_url         = local.database_url
+  discourse_login_url  = local.discourse_login_url
+  discourse_signup_url = local.discourse_signup_url
+  redis_url            = local.redis_url
+  sso_cookie_name      = local.sso_cookie_name
+  sso_jwt_secret       = local.sso_jwt_secret
 }

--- a/live/stage/services/fundraising/outputs.tf
+++ b/live/stage/services/fundraising/outputs.tf
@@ -1,14 +1,4 @@
 output "service_name" {
-  value       = "${module.fundraising.service_name}"
+  value       = module.fundraising.service_name
   description = "ECS Service name"
-}
-
-output "dns_name" {
-  value       = "${module.fundraising.dns_name}"
-  description = "ELB dns_name"
-}
-
-output "zone_id" {
-  value       = "${module.fundraising.zone_id}"
-  description = "ELB zone_id"
 }

--- a/modules/services/cluster/main.tf
+++ b/modules/services/cluster/main.tf
@@ -1,0 +1,40 @@
+/**
+ *Cluster module creates a ECS cluster and a ALB to be used by apps and services in a specific environment
+ *The cluster is created inside a VPC.
+ *
+ *This module creates all the necessary pieces that are needed to run a cluster, including:
+ *
+ ** Auto Scaling Groups
+ ** EC2 Launch Configurations
+ ** Application load balancer (ALB)
+ *
+ *## Usage:
+ *
+ *```hcl
+ *module "cluster" {
+ *  source      = "../cluster"
+ *  environment = "${var.environment}"
+ *
+ *  security_groups_ids = var.security_groups
+ *  subnet_ids = var.subnet_ids
+ *}
+ *```
+ */
+locals {
+  name = "${var.environment}-alb"
+}
+
+resource "aws_ecs_cluster" "cluster" {
+  name = var.environment
+}
+
+resource "aws_lb" "lb" {
+  name            = local.name
+  security_groups = var.security_group_ids
+  subnets         = var.subnet_ids
+
+  tags = {
+    Environment = var.environment
+    Terraform   = true
+  }
+}

--- a/modules/services/cluster/main.tf
+++ b/modules/services/cluster/main.tf
@@ -66,7 +66,7 @@ resource "aws_lb_listener" "http" {
 
 // This is the default HTTPS listener
 // Users shouldn't reach this route
-resource "aws_lb_listener" "fundraising_https" {
+resource "aws_lb_listener" "https" {
   load_balancer_arn = aws_lb.lb.id
   port              = "443"
   protocol          = "HTTPS"
@@ -78,7 +78,7 @@ resource "aws_lb_listener" "fundraising_https" {
 
     fixed_response {
       content_type = "text/plain"
-      message_body = "Here Be Dragons"
+      message_body = "Here Be Dragons."
       status_code  = "200"
     }
   }

--- a/modules/services/cluster/outputs.tf
+++ b/modules/services/cluster/outputs.tf
@@ -5,7 +5,7 @@ output "lb_id" {
 
 output "lb_arn_suffix" {
   description = "ALB arn suffix for use with CloudWatch Metrics"
-  value       = aws_lb.lb.id
+  value       = aws_lb.lb.arn_suffix
 }
 
 output "lb_dns_name" {
@@ -15,10 +15,20 @@ output "lb_dns_name" {
 
 output "lb_zone_id" {
   description = "ALB canonical hosted zone ID, to be used in a Route 53 Alias record"
-  value       = aws_lb.lb.dns_name
+  value       = aws_lb.lb.zone_id
 }
 
-output "cluster_id" {
+output "lb_listener_id" {
+  description = "ALB HTTPS listener id"
+  value       = aws_lb_listener.https.id
+}
+
+output "ecs_cluster_id" {
   description = "ECS cluster ID/ARN"
   value       = aws_ecs_cluster.cluster.id
+}
+
+output "ecs_cluster_name" {
+  description = "ECS cluster name"
+  value       = aws_ecs_cluster.cluster.name
 }

--- a/modules/services/cluster/outputs.tf
+++ b/modules/services/cluster/outputs.tf
@@ -1,0 +1,24 @@
+output "lb_id" {
+  description = "ALB id"
+  value       = aws_lb.lb.id
+}
+
+output "lb_arn_suffix" {
+  description = "ALB arn suffix for use with CloudWatch Metrics"
+  value       = aws_lb.lb.id
+}
+
+output "lb_dns_name" {
+  description = "ALB DNS name"
+  value       = aws_lb.lb.dns_name
+}
+
+output "lb_zone_id" {
+  description = "ALB canonical hosted zone ID, to be used in a Route 53 Alias record"
+  value       = aws_lb.lb.dns_name
+}
+
+output "cluster_id" {
+  description = "ECS cluster ID/ARN"
+  value       = aws_ecs_cluster.cluster.id
+}

--- a/modules/services/cluster/vars.tf
+++ b/modules/services/cluster/vars.tf
@@ -1,0 +1,11 @@
+variable "environment" {
+  type = string
+}
+
+variable "subnet_ids" {
+  type = list
+}
+
+variable "security_group_ids" {
+  type = list
+}

--- a/modules/services/cluster/vars.tf
+++ b/modules/services/cluster/vars.tf
@@ -9,3 +9,7 @@ variable "subnet_ids" {
 variable "security_group_ids" {
   type = list
 }
+
+variable "acm_certificate_domain" {
+  type = string
+}

--- a/modules/services/disputes_api/container_definitions.tf
+++ b/modules/services/disputes_api/container_definitions.tf
@@ -14,7 +14,7 @@ module "container_definitions" {
   container_name               = local.container_name
   container_cpu                = 0
   container_memory             = 0
-  container_memory_reservation = 479
+  container_memory_reservation = 230
   essential                    = true
   container_image              = var.container_image
 

--- a/modules/services/disputes_api/main.tf
+++ b/modules/services/disputes_api/main.tf
@@ -16,13 +16,6 @@
  *  environment = "${var.environment}"
  *  image       = "${var.image}"
  *
- *  key_name                = "${var.key_name}"
- *  iam_instance_profile_id = "${var.iam_instance_profile_id}"
- *  subnet_ids              = ["${var.subnet_ids}"]
- *  security_groups         = ["${var.security_groups}"]
- *  asg_min_size            = "${var.asg_min_size}"
- *  asg_max_size            = "${var.asg_max_size}"
- *
  *  database_url = "${var.database_url}"
  *  introspection = true
  *}
@@ -54,33 +47,13 @@ resource "aws_lb_listener_rule" "disputes_api" {
 
   action {
     type             = "forward"
-    target_group_arn = "${aws_lb_target_group.disputes_api.arn}"
+    target_group_arn = aws_lb_target_group.disputes_api.arn
   }
 
   condition {
     field  = "host-header"
     values = [var.domain]
   }
-}
-
-module "autoscaling" {
-  source      = "../../utils/autoscaling"
-  environment = var.environment
-
-  cluster_name            = var.ecs_cluster_name
-  key_name                = var.key_name
-  iam_instance_profile_id = var.iam_instance_profile_id
-  security_groups         = var.security_groups
-  instance_type           = var.instance_type
-  subnet_ids              = var.subnet_ids
-
-  tags = [
-    {
-      key                 = "Name"
-      value               = "disputes_api_${var.environment}"
-      propagate_at_launch = true
-    },
-  ]
 }
 
 // Create ECS task definition

--- a/modules/services/disputes_api/outputs.tf
+++ b/modules/services/disputes_api/outputs.tf
@@ -1,14 +1,4 @@
 output "service_name" {
-  value       = "${aws_ecs_service.disputes_api.name}"
+  value       = aws_ecs_service.disputes_api.name
   description = "ECS Service name"
-}
-
-output "dns_name" {
-  value       = "${aws_lb.disputes_api.dns_name}"
-  description = "ALB dns_name"
-}
-
-output "zone_id" {
-  value       = "${aws_lb.disputes_api.zone_id}"
-  description = "ALB zone_id"
 }

--- a/modules/services/disputes_api/vars.tf
+++ b/modules/services/disputes_api/vars.tf
@@ -32,7 +32,7 @@ variable "asg_min_size" {
 
 variable "asg_max_size" {
   description = "Auto Scaling Group maximum size for the cluster"
-  default     = 1
+  default     = 2
 }
 
 variable "desired_count" {
@@ -40,22 +40,29 @@ variable "desired_count" {
   default     = 1
 }
 
-variable "acm_certificate_domain" {
-  description = "ACM certificate domain name to be used for SSL"
-  default     = "*.debtcollective.org"
-}
-
 variable "vpc_id" {
-  description = "VPC Id to be used by the LB"
+  description = "VPC id to be used by the LB"
 }
 
-variable "elb_security_groups" {
-  description = "VPC Security Groups IDs to be used by the load balancer"
+variable "lb_listener_id" {
+  description = "LB listener id"
+}
+
+variable "ecs_cluster_id" {
+  description = "ECS cluster id where the app will run"
+}
+
+variable "ecs_cluster_name" {
+  description = "ECS cluster name where the app will run"
+}
+
+variable "domain" {
+  description = "FQDN where app will be available"
 }
 
 variable "instance_type" {
   description = "Instance type Launch Configuration"
-  default     = "t3.micro"
+  default     = "t3a.micro"
 }
 
 // disputes-api variables

--- a/modules/services/disputes_api/vars.tf
+++ b/modules/services/disputes_api/vars.tf
@@ -7,39 +7,6 @@ variable "container_image" {
   default     = "debtcollective/disputes-api:latest"
 }
 
-variable "key_name" {
-  description = "SSH Key Pair to be assigned to the Launch Configuration for the instances running in this cluster"
-}
-
-variable "iam_instance_profile_id" {
-  description = "IAM Profile ID to be used in the Launch Configuration for the instances running in this cluster"
-}
-
-variable "subnet_ids" {
-  description = "VPC Subnet IDs to be used in the Launch Configuration for the instances running in this cluster"
-  type        = "list"
-}
-
-variable "security_groups" {
-  description = "VPC Security Groups IDs to be used in the Launch Configuration for the instances running in this cluster"
-  type        = "list"
-}
-
-variable "asg_min_size" {
-  description = "Auto Scaling Group minimium size for the cluster"
-  default     = 1
-}
-
-variable "asg_max_size" {
-  description = "Auto Scaling Group maximum size for the cluster"
-  default     = 2
-}
-
-variable "desired_count" {
-  description = "Number of instances to be run"
-  default     = 1
-}
-
 variable "vpc_id" {
   description = "VPC id to be used by the LB"
 }
@@ -52,17 +19,13 @@ variable "ecs_cluster_id" {
   description = "ECS cluster id where the app will run"
 }
 
-variable "ecs_cluster_name" {
-  description = "ECS cluster name where the app will run"
-}
-
 variable "domain" {
   description = "FQDN where app will be available"
 }
 
-variable "instance_type" {
-  description = "Instance type Launch Configuration"
-  default     = "t3a.micro"
+variable "desired_count" {
+  description = "Number of instances to be run"
+  default     = 1
 }
 
 // disputes-api variables

--- a/modules/services/fundraising/container_definitions.tf
+++ b/modules/services/fundraising/container_definitions.tf
@@ -19,7 +19,7 @@ module "container_definitions" {
   container_name               = local.container_name
   container_cpu                = 0
   container_memory             = 0
-  container_memory_reservation = 479
+  container_memory_reservation = 230
   essential                    = true
   container_image              = var.container_image
 

--- a/modules/services/fundraising/outputs.tf
+++ b/modules/services/fundraising/outputs.tf
@@ -1,14 +1,4 @@
 output "service_name" {
-  value       = "${aws_ecs_service.fundraising.name}"
+  value       = aws_ecs_service.fundraising.name
   description = "ECS Service name"
-}
-
-output "dns_name" {
-  value       = "${aws_lb.fundraising.dns_name}"
-  description = "ALB dns_name"
-}
-
-output "zone_id" {
-  value       = "${aws_lb.fundraising.zone_id}"
-  description = "ALB zone_id"
 }

--- a/modules/services/fundraising/vars.tf
+++ b/modules/services/fundraising/vars.tf
@@ -7,55 +7,25 @@ variable "container_image" {
   default     = "debtcollective/fundraising:latest"
 }
 
-variable "key_name" {
-  description = "SSH Key Pair to be assigned to the Launch Configuration for the instances running in this cluster"
+variable "vpc_id" {
+  description = "VPC Id to be used by the LB"
 }
 
-variable "iam_instance_profile_id" {
-  description = "IAM Profile ID to be used in the Launch Configuration for the instances running in this cluster"
+variable "lb_listener_id" {
+  description = "LB listener id"
 }
 
-variable "subnet_ids" {
-  description = "VPC Subnet IDs to be used in the Launch Configuration for the instances running in this cluster"
-  type        = "list"
+variable "ecs_cluster_id" {
+  description = "ECS cluster id where the app will run"
 }
 
-variable "security_groups" {
-  description = "VPC Security Groups IDs to be used in the Launch Configuration for the instances running in this cluster"
-  type        = "list"
-}
-
-variable "asg_min_size" {
-  description = "Auto Scaling Group minimium size for the cluster"
-  default     = 1
-}
-
-variable "asg_max_size" {
-  description = "Auto Scaling Group maximum size for the cluster"
-  default     = 1
+variable "domain" {
+  description = "FQDN where app will be available"
 }
 
 variable "desired_count" {
   description = "Number of instances to be run"
   default     = 1
-}
-
-variable "acm_certificate_domain" {
-  description = "ACM certificate domain name to be used for SSL"
-  default     = "*.debtcollective.org"
-}
-
-variable "vpc_id" {
-  description = "VPC Id to be used by the LB"
-}
-
-variable "elb_security_groups" {
-  description = "VPC Security Groups IDs to be used by the load balancer"
-}
-
-variable "instance_type" {
-  description = "Instance type Launch Configuration"
-  default     = "t3.micro"
 }
 
 // Fundraising app variables

--- a/modules/services/mail_for_good/vars.tf
+++ b/modules/services/mail_for_good/vars.tf
@@ -46,7 +46,7 @@ variable "acm_certificate_domain" {
 }
 
 variable "vpc_id" {
-  description = "VPC Id to be used by the LB"
+  description = "VPC id to be used by the LB"
 }
 
 variable "elb_security_groups" {

--- a/modules/utils/autoscaling/main.tf
+++ b/modules/utils/autoscaling/main.tf
@@ -85,6 +85,7 @@ resource "aws_autoscaling_group" "asg" {
   max_size             = var.asg_max_size
   health_check_type    = "ELB"
   vpc_zone_identifier  = var.subnet_ids
+  desired_capacity     = var.asg_desired_count
 
   tags = concat(local.default_asg_tags, var.tags)
 }

--- a/modules/utils/autoscaling/user_data.sh
+++ b/modules/utils/autoscaling/user_data.sh
@@ -1,3 +1,7 @@
+# Update ECS agent on init
+sudo yum update -y ecs-init
+sudo service docker restart && sudo start ecs
+
 #!/bin/bash
 # Register instance with ECS cluster
 echo ECS_CLUSTER=${cluster_name} > /etc/ecs/ecs.config

--- a/modules/utils/autoscaling/user_data.sh
+++ b/modules/utils/autoscaling/user_data.sh
@@ -1,7 +1,3 @@
-# Update ECS agent on init
-sudo yum update -y ecs-init
-sudo service docker restart && sudo start ecs
-
 #!/bin/bash
 # Register instance with ECS cluster
 echo ECS_CLUSTER=${cluster_name} > /etc/ecs/ecs.config


### PR DESCRIPTION
**What:** Refactor services to run in one cluster per environment

**Why:** To reduce costs with instances and load balancers

**How:**

- Expose a cluster module to be used by all services
- Refactor apps to use cluster module instead of creating their own

**Notes**:

We are moving modules to execute runs in the Terraform Cloud instead of locally.

![image](https://user-images.githubusercontent.com/849872/68641073-52ac8200-04cf-11ea-87c5-badd9b535b3d.png)

We will do the same with the rest of the workspaces