### PR TITLE
Add campaign-api module and service

### DIFF
--- a/live/stage/data-stores/postgres/setup/campaign_api.tf
+++ b/live/stage/data-stores/postgres/setup/campaign_api.tf
@@ -1,0 +1,62 @@
+// Generate random username and password
+resource "random_string" "campaign_api_db_user" {
+  length  = 16
+  special = false
+}
+
+resource "random_password" "campaign_api_db_pass" {
+  length           = 20
+  special          = true
+  min_special      = 1
+  override_special = "~*^+"
+}
+
+// Store both in SSM
+resource "aws_ssm_parameter" "campaign_api_db_user" {
+  name  = "/${local.environment}/services/campaign_api/db_user"
+  type  = "String"
+  value = "campaign_api_${random_string.campaign_api_db_user.result}"
+}
+
+resource "aws_ssm_parameter" "campaign_api_db_pass" {
+  name  = "/${local.environment}/services/campaign_api/db_pass"
+  type  = "SecureString"
+  value = random_password.campaign_api_db_pass.result
+}
+
+// Create postgres role and db
+resource "postgresql_role" "campaign_api" {
+  name                = aws_ssm_parameter.campaign_api_db_user.value
+  login               = true
+  password            = aws_ssm_parameter.campaign_api_db_pass.value
+  roles               = [local.master_db_user]
+  skip_reassign_owned = true
+}
+
+resource "postgresql_database" "campaign_api" {
+  name       = "campaign_api_${local.environment}"
+  owner      = local.master_db_user
+  lc_collate = "en_US.UTF-8"
+  lc_ctype   = "en_US.UTF-8"
+  encoding   = "UTF8"
+}
+
+resource "postgresql_default_privileges" "campaign_api_tables" {
+  database    = postgresql_database.campaign_api.name
+  depends_on  = ["postgresql_database.campaign_api", "postgresql_role.campaign_api"]
+  object_type = "table"
+  owner       = local.master_db_user
+  privileges  = local.table_privileges
+  role        = postgresql_role.campaign_api.name
+  schema      = "public"
+}
+
+resource "postgresql_default_privileges" "campaign_api_sequence" {
+  database    = postgresql_database.campaign_api.name
+  depends_on  = ["postgresql_database.campaign_api", "postgresql_role.campaign_api"]
+  object_type = "sequence"
+  owner       = local.master_db_user
+  privileges  = local.sequence_privileges
+  role        = postgresql_role.campaign_api.name
+  schema      = "public"
+}

--- a/live/stage/data-stores/postgres/setup/outputs.tf
+++ b/live/stage/data-stores/postgres/setup/outputs.tf
@@ -1,3 +1,4 @@
+# Fundraising
 output "fundraising_db_user_ssm_key" {
   value = aws_ssm_parameter.fundraising_db_user.name
 }
@@ -11,6 +12,7 @@ output "fundraising_db_name" {
 
 }
 
+# Disputes API
 output "disputes_api_db_user_ssm_key" {
   value = aws_ssm_parameter.disputes_api_db_user.name
 }
@@ -24,6 +26,7 @@ output "disputes_api_db_name" {
 
 }
 
+# Mail for Good
 output "mail_for_good_db_user_ssm_key" {
   value = aws_ssm_parameter.mail_for_good_db_user.name
 }
@@ -34,4 +37,18 @@ output "mail_for_good_db_pass_ssm_key" {
 
 output "mail_for_good_db_name" {
   value = postgresql_database.mail_for_good.name
+}
+
+# Campaign API
+output "campaign_api_db_user_ssm_key" {
+  value = aws_ssm_parameter.campaign_api_db_user.name
+}
+
+output "campaign_api_db_pass_ssm_key" {
+  value = aws_ssm_parameter.campaign_api_db_pass.name
+}
+
+output "campaign_api_db_name" {
+  value = "campaign_api_${local.environment}"
+
 }

--- a/live/stage/services/campaign_api/dependencies.tf
+++ b/live/stage/services/campaign_api/dependencies.tf
@@ -1,0 +1,80 @@
+data "terraform_remote_state" "vpc" {
+  backend = "remote"
+
+  config = {
+    organization = local.remote_state_organization
+
+    workspaces = {
+      name = local.vpc_remote_state_workspace
+    }
+  }
+}
+
+data "terraform_remote_state" "cluster" {
+  backend = "remote"
+
+  config = {
+    organization = local.remote_state_organization
+
+    workspaces = {
+      name = local.cluster_remote_state_workspace
+    }
+  }
+}
+
+data "terraform_remote_state" "postgres" {
+  backend = "remote"
+
+  config = {
+    organization = local.remote_state_organization
+
+    workspaces = {
+      name = local.postgres_remote_state_workspace
+    }
+  }
+}
+
+data "terraform_remote_state" "postgres_setup" {
+  backend = "remote"
+
+  config = {
+    organization = local.remote_state_organization
+
+    workspaces = {
+      name = local.postgres_setup_remote_state_workspace
+    }
+  }
+}
+
+data "aws_ssm_parameter" "db_user" {
+  name = data.terraform_remote_state.postgres_setup.outputs.campaign_api_db_user_ssm_key
+}
+
+data "aws_ssm_parameter" "db_pass" {
+  name = data.terraform_remote_state.postgres_setup.outputs.campaign_api_db_pass_ssm_key
+}
+
+locals {
+  environment = "stage"
+
+  db_address    = data.terraform_remote_state.postgres.outputs.db_address
+  db_name       = data.terraform_remote_state.postgres_setup.outputs.campaign_api_db_name
+  db_pass       = data.aws_ssm_parameter.db_pass.value
+  db_port       = data.terraform_remote_state.postgres.outputs.db_port
+  db_user       = data.aws_ssm_parameter.db_user.value
+  database_url  = "postgres://${local.db_user}:${urlencode(local.db_pass)}@${local.db_address}:${local.db_port}/${local.db_name}"
+  introspection = true
+
+  ecs_cluster_id = data.terraform_remote_state.cluster.outputs.ecs_cluster_id
+  lb_dns_name    = data.terraform_remote_state.cluster.outputs.lb_dns_name
+  lb_listener_id = data.terraform_remote_state.cluster.outputs.lb_listener_id
+  lb_zone_id     = data.terraform_remote_state.cluster.outputs.lb_zone_id
+  vpc_id         = data.terraform_remote_state.vpc.outputs.vpc_id
+
+  cluster_remote_state_workspace        = "${local.environment}-cluster"
+  iam_remote_state_workspace            = "global-iam"
+  postgres_remote_state_workspace       = "${local.environment}-postgres"
+  postgres_setup_remote_state_workspace = "${local.environment}-postgres-setup"
+  remote_state_organization             = "debtcollective"
+  vpc_remote_state_workspace            = "${local.environment}-network"
+}

--- a/live/stage/services/campaign_api/dependencies.tf
+++ b/live/stage/services/campaign_api/dependencies.tf
@@ -64,6 +64,7 @@ locals {
   db_user       = data.aws_ssm_parameter.db_user.value
   database_url  = "postgres://${local.db_user}:${urlencode(local.db_pass)}@${local.db_address}:${local.db_port}/${local.db_name}"
   introspection = true
+  playground    = true
 
   ecs_cluster_id = data.terraform_remote_state.cluster.outputs.ecs_cluster_id
   lb_dns_name    = data.terraform_remote_state.cluster.outputs.lb_dns_name

--- a/live/stage/services/campaign_api/main.tf
+++ b/live/stage/services/campaign_api/main.tf
@@ -42,4 +42,5 @@ module "campaign_api" {
 
   database_url  = local.database_url
   introspection = local.introspection
+  playground    = local.playground
 }

--- a/live/stage/services/campaign_api/main.tf
+++ b/live/stage/services/campaign_api/main.tf
@@ -1,0 +1,45 @@
+terraform {
+  required_version = ">=0.12.13"
+
+  backend "remote" {
+    hostname     = "app.terraform.io"
+    organization = "debtcollective"
+
+    workspaces {
+      name = "stage-app-campaign-api"
+    }
+  }
+}
+
+provider "aws" {
+  version = "~> 2.0"
+}
+
+data "aws_route53_zone" "primary" {
+  name = "debtcollective.org"
+}
+
+resource "aws_route53_record" "campaign_api" {
+  zone_id = data.aws_route53_zone.primary.zone_id
+  name    = "campaign-api-${local.environment}"
+  type    = "A"
+
+  alias {
+    name                   = local.lb_dns_name
+    zone_id                = local.lb_zone_id
+    evaluate_target_health = true
+  }
+}
+
+module "campaign_api" {
+  source      = "../../../../modules/services/campaign_api"
+  environment = local.environment
+
+  domain         = aws_route53_record.campaign_api.fqdn
+  ecs_cluster_id = local.ecs_cluster_id
+  lb_listener_id = local.lb_listener_id
+  vpc_id         = local.vpc_id
+
+  database_url  = local.database_url
+  introspection = local.introspection
+}

--- a/live/stage/services/campaign_api/outputs.tf
+++ b/live/stage/services/campaign_api/outputs.tf
@@ -1,4 +1,4 @@
 output "service_name" {
-  value       = aws_ecs_service.campaign_api.name
+  value       = module.campaign_api.service_name
   description = "ECS Service name"
 }

--- a/modules/services/campaign_api/container_definitions.tf
+++ b/modules/services/campaign_api/container_definitions.tf
@@ -31,6 +31,10 @@ module "container_definitions" {
       name  = "INTROSPECTION",
       value = var.introspection
     },
+    {
+      name  = "PLAYGROUND",
+      value = var.playground
+    }
   ]
 
   port_mappings = [

--- a/modules/services/campaign_api/container_definitions.tf
+++ b/modules/services/campaign_api/container_definitions.tf
@@ -1,0 +1,47 @@
+resource "aws_cloudwatch_log_group" "campaign_api" {
+  name = "/${var.environment}/services/campaign_api"
+
+  tags = {
+    Environment = var.environment
+    Application = "campaign_api"
+    Terraform   = true
+  }
+}
+
+module "container_definitions" {
+  source = "git::https://github.com/cloudposse/terraform-aws-ecs-container-definition.git?ref=0.15.0"
+
+  container_name               = local.container_name
+  container_cpu                = 0
+  container_memory             = 0
+  container_memory_reservation = 230
+  essential                    = true
+  container_image              = var.container_image
+
+  environment = [
+    {
+      name  = "NODE_ENV",
+      value = "production"
+    },
+    {
+      name  = "DB_CONNECTION_STRING",
+      value = var.database_url
+    },
+    {
+      name  = "INTROSPECTION",
+      value = var.introspection
+    },
+  ]
+
+  port_mappings = [
+    {
+      containerPort = local.container_port
+    }
+  ]
+
+  log_driver = "awslogs"
+  log_options = {
+    "awslogs-region" = data.aws_region.current.name
+    "awslogs-group"  = aws_cloudwatch_log_group.campaign_api.name
+  }
+}

--- a/modules/services/campaign_api/container_definitions.tf
+++ b/modules/services/campaign_api/container_definitions.tf
@@ -14,7 +14,7 @@ module "container_definitions" {
   container_name               = local.container_name
   container_cpu                = 0
   container_memory             = 0
-  container_memory_reservation = 230
+  container_memory_reservation = var.container_memory_reservation
   essential                    = true
   container_image              = var.container_image
 

--- a/modules/services/campaign_api/main.tf
+++ b/modules/services/campaign_api/main.tf
@@ -1,0 +1,76 @@
+/**
+ *campaign_api module creates a ECS deployment serving the campaign-api app
+ *
+ *This module creates a ECS service to run inside a ECS cluster.
+ *
+ *## Usage:
+ *
+ *```hcl
+ *module "campaign_api" {
+ *  source      = "../../../../modules/services/campaign_api"
+ *  environment = local.environment
+ *
+ *  domain         = aws_route53_record.campaign_api.fqdn
+ *  ecs_cluster_id = local.ecs_cluster_id
+ *  lb_listener_id = local.lb_listener_id
+ *  vpc_id         = local.vpc_id
+ *
+ *  database_url  = local.database_url
+ *  introspection = local.introspection
+ *}
+ *```
+ */
+locals {
+  container_name = "campaign_api"
+  container_port = "4000"
+  name_prefix    = substr(var.environment, 0, 2)
+}
+
+data "aws_region" "current" {}
+
+// Load balancer
+resource "aws_lb_target_group" "campaign_api" {
+  name_prefix = local.name_prefix
+  port        = 80
+  protocol    = "HTTP"
+  vpc_id      = var.vpc_id
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+// Services only should define this to work correctly
+resource "aws_lb_listener_rule" "campaign_api" {
+  listener_arn = var.lb_listener_id
+
+  action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.campaign_api.arn
+  }
+
+  condition {
+    field  = "host-header"
+    values = [var.domain]
+  }
+}
+
+// Create ECS task definition
+resource "aws_ecs_task_definition" "campaign_api" {
+  family                = "campaign_api_${var.environment}"
+  container_definitions = module.container_definitions.json
+}
+
+// Create ECS service
+resource "aws_ecs_service" "campaign_api" {
+  name            = "campaign_api"
+  cluster         = var.ecs_cluster_id
+  task_definition = aws_ecs_task_definition.campaign_api.arn
+  desired_count   = var.desired_count
+
+  load_balancer {
+    target_group_arn = aws_lb_target_group.campaign_api.arn
+    container_name   = local.container_name
+    container_port   = local.container_port
+  }
+}

--- a/modules/services/campaign_api/outputs.tf
+++ b/modules/services/campaign_api/outputs.tf
@@ -1,0 +1,4 @@
+output "service_name" {
+  value       = aws_ecs_service.disputes_api.name
+  description = "ECS Service name"
+}

--- a/modules/services/campaign_api/vars.tf
+++ b/modules/services/campaign_api/vars.tf
@@ -7,6 +7,11 @@ variable "container_image" {
   default     = "debtcollective/campaign-api:latest"
 }
 
+variable "container_memory_reservation" {
+  description = "Memory reservation for containers"
+  default     = 115
+}
+
 variable "vpc_id" {
   description = "VPC id to be used by the LB"
 }

--- a/modules/services/campaign_api/vars.tf
+++ b/modules/services/campaign_api/vars.tf
@@ -41,3 +41,7 @@ variable "database_url" {
 variable "introspection" {
   description = "GraphQL introspection"
 }
+
+variable "playground" {
+  description = "GraphQL playground"
+}

--- a/modules/services/campaign_api/vars.tf
+++ b/modules/services/campaign_api/vars.tf
@@ -1,0 +1,38 @@
+variable "environment" {
+  description = "Environment name"
+}
+
+variable "container_image" {
+  description = "Docker image name"
+  default     = "debtcollective/campaign-api:latest"
+}
+
+variable "vpc_id" {
+  description = "VPC id to be used by the LB"
+}
+
+variable "lb_listener_id" {
+  description = "LB listener id"
+}
+
+variable "ecs_cluster_id" {
+  description = "ECS cluster id where the app will run"
+}
+
+variable "domain" {
+  description = "FQDN where app will be available"
+}
+
+variable "desired_count" {
+  description = "Number of instances to be run"
+  default     = 1
+}
+
+// campaign-api variables
+variable "database_url" {
+  description = "Postgres database URL"
+}
+
+variable "introspection" {
+  description = "GraphQL introspection"
+}

--- a/modules/services/disputes_api/container_definitions.tf
+++ b/modules/services/disputes_api/container_definitions.tf
@@ -14,7 +14,7 @@ module "container_definitions" {
   container_name               = local.container_name
   container_cpu                = 0
   container_memory             = 0
-  container_memory_reservation = 230
+  container_memory_reservation = var.container_memory_reservation
   essential                    = true
   container_image              = var.container_image
 

--- a/modules/services/disputes_api/main.tf
+++ b/modules/services/disputes_api/main.tf
@@ -1,23 +1,22 @@
 /**
  *disputes_api module creates a ECS deployment serving the disputes-api app
- *The cluster is created inside a VPC.
  *
- *This module creates all the necessary pieces that are needed to run a cluster, including:
- *
- ** Auto Scaling Groups
- ** EC2 Launch Configurations
- ** Application load balancer (ELB)
+ *This module creates a ECS service to run inside a ECS cluster.
  *
  *## Usage:
  *
  *```hcl
  *module "disputes_api" {
- *  source      = "../services/disputes_api"
- *  environment = "${var.environment}"
- *  image       = "${var.image}"
+ *  source      = "../../../../modules/services/disputes_api"
+ *  environment = local.environment
  *
- *  database_url = "${var.database_url}"
- *  introspection = true
+ *  domain         = aws_route53_record.disputes_api.fqdn
+ *  ecs_cluster_id = local.ecs_cluster_id
+ *  lb_listener_id = local.lb_listener_id
+ *  vpc_id         = local.vpc_id
+ *
+ *  database_url  = local.database_url
+ *  introspection = local.introspection
  *}
  *```
  */
@@ -58,7 +57,7 @@ resource "aws_lb_listener_rule" "disputes_api" {
 
 // Create ECS task definition
 resource "aws_ecs_task_definition" "disputes_api" {
-  family                = "disputes_api-${var.environment}"
+  family                = "disputes_api_${var.environment}"
   container_definitions = module.container_definitions.json
 }
 

--- a/modules/services/disputes_api/vars.tf
+++ b/modules/services/disputes_api/vars.tf
@@ -7,6 +7,11 @@ variable "container_image" {
   default     = "debtcollective/disputes-api:latest"
 }
 
+variable "container_memory_reservation" {
+  description = "Memory reservation for containers"
+  default     = 115
+}
+
 variable "vpc_id" {
   description = "VPC id to be used by the LB"
 }

--- a/modules/services/fundraising/container_definitions.tf
+++ b/modules/services/fundraising/container_definitions.tf
@@ -19,7 +19,7 @@ module "container_definitions" {
   container_name               = local.container_name
   container_cpu                = 0
   container_memory             = 0
-  container_memory_reservation = 230
+  container_memory_reservation = var.container_memory_reservation
   essential                    = true
   container_image              = var.container_image
 

--- a/modules/services/fundraising/main.tf
+++ b/modules/services/fundraising/main.tf
@@ -65,7 +65,7 @@ resource "aws_lb_listener_rule" "fundraising" {
 
 // Create ECS task definition
 resource "aws_ecs_task_definition" "fundraising" {
-  family                = "fundraising-${var.environment}"
+  family                = "fundraising_${var.environment}"
   container_definitions = module.container_definitions.json
 }
 

--- a/modules/services/fundraising/vars.tf
+++ b/modules/services/fundraising/vars.tf
@@ -7,6 +7,11 @@ variable "container_image" {
   default     = "debtcollective/fundraising:latest"
 }
 
+variable "container_memory_reservation" {
+  description = "Memory reservation for containers"
+  default     = 115
+}
+
 variable "vpc_id" {
   description = "VPC Id to be used by the LB"
 }

--- a/modules/services/mail_for_good/container_definitions.tf
+++ b/modules/services/mail_for_good/container_definitions.tf
@@ -19,7 +19,7 @@ module "container_definitions" {
   container_name               = local.container_name
   container_cpu                = 0
   container_memory             = 0
-  container_memory_reservation = 479
+  container_memory_reservation = var.container_memory_reservation
   essential                    = true
   container_image              = var.container_image
 

--- a/modules/services/mail_for_good/vars.tf
+++ b/modules/services/mail_for_good/vars.tf
@@ -7,6 +7,11 @@ variable "container_image" {
   default     = "freecodecamp/mail-for-good:latest"
 }
 
+variable "container_memory_reservation" {
+  description = "Memory reservation for containers"
+  default     = 115
+}
+
 variable "key_name" {
   description = "SSH Key Pair to be assigned to the Launch Configuration for the instances running in this cluster"
 }


### PR DESCRIPTION
**What:** Add campaign-api module and service

**Why:** To have the campaign-api, related to https://github.com/debtcollective/campaign-api/issues/7

**How:**

Use the disputes-api module as template. The resulting module adds:

- Postgres user, role and database
- ECS deployment adding a service to the `stage` ECS cluster