### PR TITLE
dev: add health-checks for disputes_api and campaign_api

### DIFF
--- a/modules/services/campaign_api/main.tf
+++ b/modules/services/campaign_api/main.tf
@@ -35,6 +35,10 @@ resource "aws_lb_target_group" "campaign_api" {
   protocol    = "HTTP"
   vpc_id      = var.vpc_id
 
+  health_check {
+    path = "/.well-known/apollo/server-health"
+  }
+
   lifecycle {
     create_before_destroy = true
   }

--- a/modules/services/disputes_api/main.tf
+++ b/modules/services/disputes_api/main.tf
@@ -35,6 +35,10 @@ resource "aws_lb_target_group" "disputes_api" {
   protocol    = "HTTP"
   vpc_id      = var.vpc_id
 
+  health_check {
+    path = "/.well-known/apollo/server-health"
+  }
+
   lifecycle {
     create_before_destroy = true
   }


### PR DESCRIPTION
**What:** add health-checks for disputes_api and campaign_api

**Why:** This is for ELB to check if the app healthy.

**How:**

Apollo has a built-in path to check if the server is running https://www.apollographql.com/docs/apollo-server/monitoring/health-checks/. For now, this is enough, if we need a more specific health-check we can follow the instructions in that link
