### PR TITLE
Remove URL prefix from Staging

### DIFF
--- a/live/stage/services/campaign_api/dependencies.tf
+++ b/live/stage/services/campaign_api/dependencies.tf
@@ -54,17 +54,27 @@ data "aws_ssm_parameter" "db_pass" {
   name = data.terraform_remote_state.postgres_setup.outputs.campaign_api_db_pass_ssm_key
 }
 
+// hard coded until we migrate Discourse to this repo
+data "aws_ssm_parameter" "discourse_sso_jwt_secret" {
+  name = "/production/services/discourse/sso_jwt_secret"
+}
+
 locals {
   environment = "stage"
 
-  db_address    = data.terraform_remote_state.postgres.outputs.db_address
-  db_name       = data.terraform_remote_state.postgres_setup.outputs.campaign_api_db_name
-  db_pass       = data.aws_ssm_parameter.db_pass.value
-  db_port       = data.terraform_remote_state.postgres.outputs.db_port
-  db_user       = data.aws_ssm_parameter.db_user.value
-  database_url  = "postgres://${local.db_user}:${urlencode(local.db_pass)}@${local.db_address}:${local.db_port}/${local.db_name}"
-  introspection = true
-  playground    = true
+  database_url         = "postgres://${local.db_user}:${urlencode(local.db_pass)}@${local.db_address}:${local.db_port}/${local.db_name}"
+  db_address           = data.terraform_remote_state.postgres.outputs.db_address
+  db_name              = data.terraform_remote_state.postgres_setup.outputs.campaign_api_db_name
+  db_pass              = data.aws_ssm_parameter.db_pass.value
+  db_port              = data.terraform_remote_state.postgres.outputs.db_port
+  db_user              = data.aws_ssm_parameter.db_user.value
+  discourse_login_url  = "${local.discourse_uri}/session/sso_cookies"
+  discourse_signup_url = "${local.discourse_uri}/session/sso_cookies/signup"
+  discourse_uri        = "https://community.debtcollective.org"
+  introspection        = true
+  playground           = true
+  sso_cookie_name      = "tdc_auth_production"
+  sso_jwt_secret       = data.aws_ssm_parameter.discourse_sso_jwt_secret.value
 
   ecs_cluster_id = data.terraform_remote_state.cluster.outputs.ecs_cluster_id
   lb_dns_name    = data.terraform_remote_state.cluster.outputs.lb_dns_name

--- a/live/stage/services/campaign_api/dependencies.tf
+++ b/live/stage/services/campaign_api/dependencies.tf
@@ -75,6 +75,7 @@ locals {
   playground           = true
   sso_cookie_name      = "tdc_auth_production"
   sso_jwt_secret       = data.aws_ssm_parameter.discourse_sso_jwt_secret.value
+  cors_origin          = "https://campaign.debtcollective.org"
 
   ecs_cluster_id = data.terraform_remote_state.cluster.outputs.ecs_cluster_id
   lb_dns_name    = data.terraform_remote_state.cluster.outputs.lb_dns_name

--- a/live/stage/services/campaign_api/main.tf
+++ b/live/stage/services/campaign_api/main.tf
@@ -47,4 +47,5 @@ module "campaign_api" {
   playground           = local.playground
   sso_cookie_name      = local.sso_cookie_name
   sso_jwt_secret       = local.sso_jwt_secret
+  cors_origin          = local.cors_origin
 }

--- a/live/stage/services/campaign_api/main.tf
+++ b/live/stage/services/campaign_api/main.tf
@@ -21,7 +21,7 @@ data "aws_route53_zone" "primary" {
 
 resource "aws_route53_record" "campaign_api" {
   zone_id = data.aws_route53_zone.primary.zone_id
-  name    = "campaign-api-${local.environment}"
+  name    = "campaign-api"
   type    = "A"
 
   alias {
@@ -40,7 +40,11 @@ module "campaign_api" {
   lb_listener_id = local.lb_listener_id
   vpc_id         = local.vpc_id
 
-  database_url  = local.database_url
-  introspection = local.introspection
-  playground    = local.playground
+  database_url         = local.database_url
+  discourse_login_url  = local.discourse_login_url
+  discourse_signup_url = local.discourse_signup_url
+  introspection        = local.introspection
+  playground           = local.playground
+  sso_cookie_name      = local.sso_cookie_name
+  sso_jwt_secret       = local.sso_jwt_secret
 }

--- a/live/stage/services/cluster/main.tf
+++ b/live/stage/services/cluster/main.tf
@@ -47,6 +47,8 @@ module "autoscaling" {
 
 // server working hours
 resource "aws_autoscaling_schedule" "working_hours" {
+  // disable it for now
+  count                  = 0
   scheduled_action_name  = "working hours"
   min_size               = 1
   max_size               = 2
@@ -57,6 +59,8 @@ resource "aws_autoscaling_schedule" "working_hours" {
 
 // turn off servers at night
 resource "aws_autoscaling_schedule" "off_working_hours" {
+  // disable it for now
+  count                  = 0
   scheduled_action_name  = "off working hours"
   min_size               = 0
   max_size               = 0

--- a/live/stage/services/fundraising/main.tf
+++ b/live/stage/services/fundraising/main.tf
@@ -40,12 +40,14 @@ module "fundraising" {
   lb_listener_id = local.lb_listener_id
   vpc_id         = local.vpc_id
 
-  database_url         = local.database_url
-  discourse_login_url  = local.discourse_login_url
-  discourse_signup_url = local.discourse_signup_url
-  redis_url            = local.redis_url
-  sso_cookie_name      = local.sso_cookie_name
-  sso_jwt_secret       = local.sso_jwt_secret
-  recaptcha_site_key   = var.recaptcha_site_key
-  recaptcha_secret_key = var.recaptcha_secret_key
+  database_url           = local.database_url
+  discourse_login_url    = local.discourse_login_url
+  discourse_signup_url   = local.discourse_signup_url
+  redis_url              = local.redis_url
+  sso_cookie_name        = local.sso_cookie_name
+  sso_jwt_secret         = local.sso_jwt_secret
+  recaptcha_site_key     = var.recaptcha_site_key
+  recaptcha_secret_key   = var.recaptcha_secret_key
+  stripe_secret_key      = var.stripe_secret_key
+  stripe_publishable_key = var.stripe_publishable_key
 }

--- a/live/stage/services/fundraising/main.tf
+++ b/live/stage/services/fundraising/main.tf
@@ -21,7 +21,7 @@ data "aws_route53_zone" "primary" {
 
 resource "aws_route53_record" "fundraising" {
   zone_id = data.aws_route53_zone.primary.zone_id
-  name    = "fundraising-${local.environment}"
+  name    = "fundraising"
   type    = "A"
 
   alias {
@@ -46,4 +46,6 @@ module "fundraising" {
   redis_url            = local.redis_url
   sso_cookie_name      = local.sso_cookie_name
   sso_jwt_secret       = local.sso_jwt_secret
+  recaptcha_site_key   = var.recaptcha_site_key
+  recaptcha_secret_key = var.recaptcha_secret_key
 }

--- a/live/stage/services/fundraising/vars.tf
+++ b/live/stage/services/fundraising/vars.tf
@@ -6,3 +6,11 @@ variable "recaptcha_site_key" {
 variable "recaptcha_secret_key" {
   description = "reCAPTCHA secret key"
 }
+
+variable "stripe_secret_key" {
+  description = "Stripe secret key"
+}
+
+variable "stripe_publishable_key" {
+  description = "Stripe publishable key"
+}

--- a/live/stage/services/fundraising/vars.tf
+++ b/live/stage/services/fundraising/vars.tf
@@ -1,0 +1,8 @@
+// Fundraising app variables
+variable "recaptcha_site_key" {
+  description = "reCAPTCHA site key"
+}
+
+variable "recaptcha_secret_key" {
+  description = "reCAPTCHA secret key"
+}

--- a/modules/services/campaign_api/container_definitions.tf
+++ b/modules/services/campaign_api/container_definitions.tf
@@ -44,6 +44,10 @@ module "container_definitions" {
       value = var.sso_jwt_secret
     },
     {
+      name  = "CORS_ORIGIN",
+      value = var.cors_origin
+    },
+    {
       name  = "INTROSPECTION",
       value = var.introspection
     },

--- a/modules/services/campaign_api/container_definitions.tf
+++ b/modules/services/campaign_api/container_definitions.tf
@@ -28,6 +28,22 @@ module "container_definitions" {
       value = var.database_url
     },
     {
+      name  = "DISCOURSE_LOGIN_URL",
+      value = var.discourse_login_url
+    },
+    {
+      name  = "DISCOURSE_SIGNUP_URL",
+      value = var.discourse_signup_url
+    },
+    {
+      name  = "SSO_COOKIE_NAME",
+      value = var.sso_cookie_name
+    },
+    {
+      name  = "SSO_JWT_SECRET",
+      value = var.sso_jwt_secret
+    },
+    {
       name  = "INTROSPECTION",
       value = var.introspection
     },

--- a/modules/services/campaign_api/vars.tf
+++ b/modules/services/campaign_api/vars.tf
@@ -45,3 +45,19 @@ variable "introspection" {
 variable "playground" {
   description = "GraphQL playground"
 }
+
+variable "sso_cookie_name" {
+  description = "SSO cookie name as defined in Discourse"
+}
+
+variable "sso_jwt_secret" {
+  description = "SSO JWT secret as defined in Discourse"
+}
+
+variable "discourse_login_url" {
+  description = "SSO login URL"
+}
+
+variable "discourse_signup_url" {
+  description = "SSO signup URL"
+}

--- a/modules/services/campaign_api/vars.tf
+++ b/modules/services/campaign_api/vars.tf
@@ -61,3 +61,7 @@ variable "discourse_login_url" {
 variable "discourse_signup_url" {
   description = "SSO signup URL"
 }
+
+variable "cors_origin" {
+  description = "Host allowed to query the API using CORS"
+}

--- a/modules/services/fundraising/container_definitions.tf
+++ b/modules/services/fundraising/container_definitions.tf
@@ -49,6 +49,10 @@ module "container_definitions" {
       value = var.discourse_signup_url
     },
     {
+      name  = "DISCOURSE_ADMIN_ROLE",
+      value = var.discourse_admin_role
+    },
+    {
       name  = "SECRET_KEY_BASE",
       value = random_string.secret_key_base.result
     },
@@ -65,9 +69,17 @@ module "container_definitions" {
       value = var.sso_jwt_secret
     },
     {
+      name  = "RECAPTCHA_SITE_KEY",
+      value = var.recaptcha_site_key
+    },
+    {
+      name  = "RECAPTCHA_SECRET_KEY",
+      value = var.recaptcha_secret_key
+    },
+    {
       name  = "PORT",
       value = local.container_port
-    }
+    },
   ]
 
   port_mappings = [

--- a/modules/services/fundraising/container_definitions.tf
+++ b/modules/services/fundraising/container_definitions.tf
@@ -77,6 +77,14 @@ module "container_definitions" {
       value = var.recaptcha_secret_key
     },
     {
+      name  = "STRIPE_SECRET_KEY",
+      value = var.stripe_secret_key
+    },
+    {
+      name  = "STRIPE_PUBLISHABLE_KEY",
+      value = var.stripe_publishable_key
+    },
+    {
       name  = "PORT",
       value = local.container_port
     },

--- a/modules/services/fundraising/vars.tf
+++ b/modules/services/fundraising/vars.tf
@@ -70,3 +70,11 @@ variable "discourse_admin_role" {
   description = "Role with access to the admin backend"
   default     = "dispute_pro"
 }
+
+variable "stripe_secret_key" {
+  description = "Stripe secret key"
+}
+
+variable "stripe_publishable_key" {
+  description = "Stripe publishable key"
+}

--- a/modules/services/fundraising/vars.tf
+++ b/modules/services/fundraising/vars.tf
@@ -57,3 +57,16 @@ variable "discourse_login_url" {
 variable "discourse_signup_url" {
   description = "SSO signup URL"
 }
+
+variable "recaptcha_site_key" {
+  description = "reCAPTCHA site key"
+}
+
+variable "recaptcha_secret_key" {
+  description = "reCAPTCHA secret key"
+}
+
+variable "discourse_admin_role" {
+  description = "Role with access to the admin backend"
+  default     = "dispute_pro"
+}


### PR DESCRIPTION
**What:** Remove URL prefix from Staging

**Why:** To start testing our env with the right URLs. We will proper production env before the launch

**How:**

- Change URLs to not have the env suffix
- Disable autoscaling schedule rule
- Update variables and configuration for campaign and fundraising apps
