### PR TITLE
feat(fundraising): add sentry integration

### DIFF
--- a/live/stage/services/fundraising/main.tf
+++ b/live/stage/services/fundraising/main.tf
@@ -50,4 +50,5 @@ module "fundraising" {
   recaptcha_secret_key   = var.recaptcha_secret_key
   stripe_secret_key      = var.stripe_secret_key
   stripe_publishable_key = var.stripe_publishable_key
+  sentry_dsn             = var.sentry_dsn
 }

--- a/live/stage/services/fundraising/vars.tf
+++ b/live/stage/services/fundraising/vars.tf
@@ -14,3 +14,7 @@ variable "stripe_secret_key" {
 variable "stripe_publishable_key" {
   description = "Stripe publishable key"
 }
+
+variable "sentry_dsn" {
+  description = "Sentry DSN"
+}

--- a/modules/services/fundraising/container_definitions.tf
+++ b/modules/services/fundraising/container_definitions.tf
@@ -85,6 +85,10 @@ module "container_definitions" {
       value = var.stripe_publishable_key
     },
     {
+      name  = "SENTRY_DSN",
+      value = var.sentry_dsn
+    },
+    {
       name  = "PORT",
       value = local.container_port
     },

--- a/modules/services/fundraising/vars.tf
+++ b/modules/services/fundraising/vars.tf
@@ -78,3 +78,7 @@ variable "stripe_secret_key" {
 variable "stripe_publishable_key" {
   description = "Stripe publishable key"
 }
+
+variable "sentry_dsn" {
+  description = "Sentry DSN"
+}


### PR DESCRIPTION
**What:** add sentry integration

**Why:** To make Sentry work after merging https://github.com/debtcollective/fundraising/pull/149

**How:**

- Add `sentry_dsn` tf variable. This needs to be configured in the terraform cloud backend
