### PR TITLE
feat(campaign-api): add sentry dsn

### DIFF
--- a/live/stage/services/campaign_api/main.tf
+++ b/live/stage/services/campaign_api/main.tf
@@ -48,4 +48,5 @@ module "campaign_api" {
   sso_cookie_name      = local.sso_cookie_name
   sso_jwt_secret       = local.sso_jwt_secret
   cors_origin          = local.cors_origin
+  sentry_dsn           = var.sentry_dsn
 }

--- a/live/stage/services/campaign_api/vars.tf
+++ b/live/stage/services/campaign_api/vars.tf
@@ -1,0 +1,3 @@
+variable "sentry_dsn" {
+  description = "Sentry DSN"
+}

--- a/modules/services/campaign_api/container_definitions.tf
+++ b/modules/services/campaign_api/container_definitions.tf
@@ -48,6 +48,10 @@ module "container_definitions" {
       value = var.cors_origin
     },
     {
+      name  = "SENTRY_DSN",
+      value = var.sentry_dsn
+    },
+    {
       name  = "INTROSPECTION",
       value = var.introspection
     },

--- a/modules/services/campaign_api/vars.tf
+++ b/modules/services/campaign_api/vars.tf
@@ -65,3 +65,7 @@ variable "discourse_signup_url" {
 variable "cors_origin" {
   description = "Host allowed to query the API using CORS"
 }
+
+variable "sentry_dsn" {
+  description = "Sentry DSN"
+}


### PR DESCRIPTION
**What:** Add `sentry_dsn` variable to campaign-api

**Why:** Related to https://github.com/debtcollective/campaign-api/pull/18

**How:**

- Add `sentry_dsn` tf variable
- Add `SENTRY_DSN` env variable to `container_definitions.tf`