### PR TITLE
dev(discourse): fix cdn issue

### DIFF
--- a/live/prod/services/discourse/dependencies.tf
+++ b/live/prod/services/discourse/dependencies.tf
@@ -62,10 +62,11 @@ locals {
   domain                 = "debtcollective.org"
   fqdn                   = "${local.subdomain}.debtcollective.org"
   s3_origin_id           = "discourse-${local.environment}"
+  ec2_origin_id          = "discourse-assets-origin-${local.environment}"
   uploads_bucket_name    = "discourse-uploads-${local.environment}"
   backups_bucket_name    = "discourse-backups-${local.environment}"
   cdn_alias              = "community-cdn-${local.environment}"
-  cdn_url                = "https://${aws_route53_record.cdn.fqdn}"
+  s3_cdn_url             = "https://${aws_route53_record.cdn.fqdn}"
   sso_cookie_name        = "tdc_auth_production"
 
   db_address = data.terraform_remote_state.postgres.outputs.db_address

--- a/live/prod/services/discourse/main.tf
+++ b/live/prod/services/discourse/main.tf
@@ -32,7 +32,8 @@ module "discourse" {
   environment = local.environment
 
   domain             = local.fqdn
-  cdn_url            = local.cdn_url
+  s3_cdn_url         = local.s3_cdn_url
+  cdn_url            = aws_cloudfront_distribution.assets.domain_name
   discourse_hostname = local.fqdn
 
   discourse_smtp_address  = var.discourse_smtp_address

--- a/modules/services/discourse/main.tf
+++ b/modules/services/discourse/main.tf
@@ -42,6 +42,8 @@ resource "aws_instance" "discourse" {
     # web.yml file
     web_yml_b64 = base64encode(
       templatefile("${path.module}/web.yml", {
+        discourse_cdn_url = var.cdn_url
+
         discourse_smtp_port             = var.discourse_smtp_port
         discourse_smtp_username         = var.discourse_smtp_username
         discourse_smtp_password         = var.discourse_smtp_password

--- a/modules/services/discourse/vars.tf
+++ b/modules/services/discourse/vars.tf
@@ -133,8 +133,12 @@ variable "domain" {
   description = "Fully Qualified Domain Name"
 }
 
+variable "s3_cdn_url" {
+  description = "Uploads CDN URL. ex: https://cdn-uploads.debtcollective.org"
+}
+
 variable "cdn_url" {
-  description = "ex: https://cdn.debtcollective.org"
+  description = "Assets CDN URL. ex: https://cdn-assets.debtcollective.org"
 }
 
 variable "discourse_uploads_bucket_name" {

--- a/modules/services/discourse/web.yml
+++ b/modules/services/discourse/web.yml
@@ -1,5 +1,6 @@
 ---
 env:
+  DISCOURSE_CDN_URL: '${discourse_cdn_url}'
   DISCOURSE_DB_HOST: '${discourse_db_host}'
   DISCOURSE_DB_NAME: '${discourse_db_name}'
   DISCOURSE_DB_PASSWORD: '${discourse_db_password}'


### PR DESCRIPTION
**What:** fix discourse cdn. 

**Why:** Pending work from infra migration. Got some directions here https://meta.discourse.org/t/assets-not-serving-from-cdn-in-latest-update/140705/13?u=eatcodetravel

**How:**

- Create a new cloud distribution for assets and pass it via `DISCOURSE_CDN_URL`