### PR TITLE
Add monitoring to services with Cloudwatch

### DIFF
--- a/live/prod/extras/notify_slack/main.tf
+++ b/live/prod/extras/notify_slack/main.tf
@@ -1,0 +1,37 @@
+terraform {
+  required_version = ">=0.12.20"
+
+  backend "remote" {
+    hostname     = "app.terraform.io"
+    organization = "debtcollective"
+
+    workspaces {
+      name = "prod-extras-notify-slack"
+    }
+  }
+}
+
+provider "aws" {
+  version = "~> 2.0"
+}
+
+locals {
+  environment = "prod"
+}
+
+module "notify_slack" {
+  source = "git::https://github.com/terraform-aws-modules/terraform-aws-notify-slack.git?ref=tags/v2.10.0"
+
+  sns_topic_name = "notify-slack-${local.environment}-topic"
+
+  slack_webhook_url = var.slack_webhook_url
+  slack_channel     = var.slack_channel
+  slack_username    = var.slack_username
+
+  lambda_description = "Lambda function which sends notifications to Slack"
+
+  tags = {
+    Name      = "cloudwatch-alerts-to-slack-${local.environment}"
+    Terraform = true
+  }
+}

--- a/live/prod/extras/notify_slack/outputs.tf
+++ b/live/prod/extras/notify_slack/outputs.tf
@@ -1,0 +1,4 @@
+output "slack_topic_arn" {
+  description = "Slack SNS Topic ARN"
+  value       = module.notify_slack.this_slack_topic_arn
+}

--- a/live/prod/extras/notify_slack/vars.tf
+++ b/live/prod/extras/notify_slack/vars.tf
@@ -1,0 +1,14 @@
+variable "slack_webhook_url" {
+  description = "slack webhook url to post messages"
+  type        = string
+}
+
+variable "slack_channel" {
+  description = "slack channel to post messages"
+  type        = string
+}
+
+variable "slack_username" {
+  description = "slack user author of the messages"
+  type        = string
+}

--- a/live/prod/services/cluster/dependencies.tf
+++ b/live/prod/services/cluster/dependencies.tf
@@ -22,6 +22,18 @@ data "terraform_remote_state" "vpc" {
   }
 }
 
+data "terraform_remote_state" "notify_slack" {
+  backend = "remote"
+
+  config = {
+    organization = local.remote_state_organization
+
+    workspaces = {
+      name = local.notify_slack_remote_state_workspace
+    }
+  }
+}
+
 locals {
   environment = "prod"
 
@@ -35,8 +47,10 @@ locals {
   subnet_ids              = data.terraform_remote_state.vpc.outputs.public_subnet_ids
   vpc_id                  = data.terraform_remote_state.vpc.outputs.vpc_id
 
-  iam_remote_state_workspace = "global-iam"
-  remote_state_organization  = "debtcollective"
-  vpc_remote_state_workspace = "${local.environment}-network"
+  slack_topic_arn = data.terraform_remote_state.notify_slack.outputs.slack_topic_arn
 
+  iam_remote_state_workspace          = "global-iam"
+  remote_state_organization           = "debtcollective"
+  vpc_remote_state_workspace          = "${local.environment}-network"
+  notify_slack_remote_state_workspace = "${local.environment}-extras-notify-slack"
 }

--- a/live/prod/services/cluster/main.tf
+++ b/live/prod/services/cluster/main.tf
@@ -22,6 +22,7 @@ module "cluster" {
   acm_certificate_domain = "*.debtcollective.org"
   security_group_ids     = local.elb_security_group_ids
   subnet_ids             = local.subnet_ids
+  monitoring             = true
 }
 
 // Autoscaling and launch configurations for this cluster

--- a/live/prod/services/cluster/main.tf
+++ b/live/prod/services/cluster/main.tf
@@ -23,6 +23,7 @@ module "cluster" {
   security_group_ids     = local.elb_security_group_ids
   subnet_ids             = local.subnet_ids
   monitoring             = true
+  slack_topic_arn        = local.slack_topic_arn
 }
 
 // Autoscaling and launch configurations for this cluster
@@ -46,28 +47,4 @@ module "autoscaling" {
       propagate_at_launch = true
     },
   ]
-}
-
-// server working hours
-resource "aws_autoscaling_schedule" "working_hours" {
-  // disable it for now
-  count                  = 0
-  scheduled_action_name  = "working hours"
-  min_size               = 1
-  max_size               = 2
-  desired_capacity       = 1
-  recurrence             = "00 12 * * 1-5" #Mon-Fri at 7AM EST
-  autoscaling_group_name = module.autoscaling.autoscaling_group_name
-}
-
-// turn off servers at night
-resource "aws_autoscaling_schedule" "off_working_hours" {
-  // disable it for now
-  count                  = 0
-  scheduled_action_name  = "off working hours"
-  min_size               = 0
-  max_size               = 0
-  desired_capacity       = 0
-  recurrence             = "00 03 * * 1-5" #Mon-Fri at 10PM EST
-  autoscaling_group_name = module.autoscaling.autoscaling_group_name
 }

--- a/live/prod/services/discourse/dependencies.tf
+++ b/live/prod/services/discourse/dependencies.tf
@@ -46,6 +46,18 @@ data "terraform_remote_state" "postgres_setup" {
   }
 }
 
+data "terraform_remote_state" "notify_slack" {
+  backend = "remote"
+
+  config = {
+    organization = local.remote_state_organization
+
+    workspaces = {
+      name = local.notify_slack_remote_state_workspace
+    }
+  }
+}
+
 data "aws_ssm_parameter" "db_user" {
   name = data.terraform_remote_state.postgres_setup.outputs.discourse_db_user_ssm_key
 }
@@ -81,10 +93,13 @@ locals {
   ec2_security_group_id = data.terraform_remote_state.vpc.outputs.ec2_security_group_id
   instance_type         = "t3a.small"
 
+  slack_topic_arn = data.terraform_remote_state.notify_slack.outputs.slack_topic_arn
+
   cluster_remote_state_workspace        = "${local.environment}-cluster"
   iam_remote_state_workspace            = "global-iam"
   postgres_remote_state_workspace       = "${local.environment}-postgres"
   postgres_setup_remote_state_workspace = "${local.environment}-postgres-setup"
   remote_state_organization             = "debtcollective"
   vpc_remote_state_workspace            = "${local.environment}-network"
+  notify_slack_remote_state_workspace   = "${local.environment}-extras-notify-slack"
 }

--- a/live/prod/services/discourse/main.tf
+++ b/live/prod/services/discourse/main.tf
@@ -35,7 +35,9 @@ module "discourse" {
   s3_cdn_url         = local.s3_cdn_url
   cdn_url            = aws_cloudfront_distribution.assets.domain_name
   discourse_hostname = local.fqdn
-  monitoring         = true
+
+  monitoring      = true
+  slack_topic_arn = local.slack_topic_arn
 
   discourse_smtp_address  = var.discourse_smtp_address
   discourse_smtp_username = var.discourse_smtp_username
@@ -71,4 +73,5 @@ module "discourse" {
   key_name        = local.ssh_key_pair_name
   subnet_id       = local.subnet_id
   security_groups = local.ec2_security_group_id
+
 }

--- a/live/prod/services/discourse/main.tf
+++ b/live/prod/services/discourse/main.tf
@@ -35,6 +35,7 @@ module "discourse" {
   s3_cdn_url         = local.s3_cdn_url
   cdn_url            = aws_cloudfront_distribution.assets.domain_name
   discourse_hostname = local.fqdn
+  monitoring         = true
 
   discourse_smtp_address  = var.discourse_smtp_address
   discourse_smtp_username = var.discourse_smtp_username

--- a/modules/services/cluster/main.tf
+++ b/modules/services/cluster/main.tf
@@ -25,6 +25,11 @@ locals {
 
 resource "aws_ecs_cluster" "cluster" {
   name = var.environment
+
+  setting {
+    name  = "containerInsights"
+    value = var.monitoring == true ? "enabled" : "disabled"
+  }
 }
 
 resource "aws_lb" "lb" {

--- a/modules/services/cluster/main.tf
+++ b/modules/services/cluster/main.tf
@@ -88,3 +88,43 @@ resource "aws_lb_listener" "https" {
     }
   }
 }
+
+resource "aws_cloudwatch_metric_alarm" "high_cpu_usage" {
+  count = var.monitoring == true ? 1 : 0
+
+  alarm_name          = "${var.environment}-cluster-high-cpu-usage"
+  alarm_description   = "This metric monitors ec2 cpu utilization"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "3"
+  metric_name         = "CPUUtilization"
+  namespace           = "AWS/ECS"
+  period              = "60"
+  statistic           = "Average"
+  threshold           = "80"
+
+  dimensions = {
+    ClusterName = aws_ecs_cluster.cluster.name
+  }
+
+  alarm_actions = [var.slack_topic_arn]
+}
+
+resource "aws_cloudwatch_metric_alarm" "high_memory_usage" {
+  count = var.monitoring == true ? 1 : 0
+
+  alarm_name          = "${var.environment}-cluster-high-memory-usage"
+  alarm_description   = "This metric monitors ec2 memory utilization"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "3"
+  metric_name         = "MemoryUtilization"
+  namespace           = "AWS/ECS"
+  period              = "60"
+  statistic           = "Average"
+  threshold           = "80"
+
+  dimensions = {
+    ClusterName = aws_ecs_cluster.cluster.name
+  }
+
+  alarm_actions = [var.slack_topic_arn]
+}

--- a/modules/services/cluster/vars.tf
+++ b/modules/services/cluster/vars.tf
@@ -18,3 +18,8 @@ variable "monitoring" {
   description = "If true, enables Cloudwatch Container Insights for this cluster"
   default     = false
 }
+
+variable "slack_topic_arn" {
+  description = "Slack SNS topic ARN used for Cloudwatch alerts"
+  default     = ""
+}

--- a/modules/services/cluster/vars.tf
+++ b/modules/services/cluster/vars.tf
@@ -13,3 +13,8 @@ variable "security_group_ids" {
 variable "acm_certificate_domain" {
   type = string
 }
+
+variable "monitoring" {
+  description = "If true, enables Cloudwatch Container Insights for this cluster"
+  default     = false
+}

--- a/modules/services/discourse/main.tf
+++ b/modules/services/discourse/main.tf
@@ -38,6 +38,8 @@ resource "aws_instance" "discourse" {
   vpc_security_group_ids = [var.security_groups]
   ami                    = data.aws_ami.ubuntu.id
   subnet_id              = var.subnet_id
+  monitoring             = var.monitoring
+
   user_data = templatefile("${path.module}/cloud-config.yml", {
     # web.yml file
     web_yml_b64 = base64encode(

--- a/modules/services/discourse/vars.tf
+++ b/modules/services/discourse/vars.tf
@@ -134,6 +134,11 @@ variable "monitoring" {
   default     = false
 }
 
+variable "slack_topic_arn" {
+  description = "Slack SNS topic ARN used for Cloudwatch alerts"
+  default     = ""
+}
+
 variable "domain" {
   description = "Fully Qualified Domain Name"
 }
@@ -145,7 +150,6 @@ variable "s3_cdn_url" {
 variable "cdn_url" {
   description = "Assets CDN URL. ex: https://cdn-assets.debtcollective.org"
 }
-
 
 variable "discourse_uploads_bucket_name" {
   description = "Uploads S3 bucket name"

--- a/modules/services/discourse/vars.tf
+++ b/modules/services/discourse/vars.tf
@@ -129,6 +129,11 @@ variable "volume_size" {
   default     = 20
 }
 
+variable "monitoring" {
+  description = "If true, enables Cloudwatch Detailed Monitoring for the EC2 instance"
+  default     = false
+}
+
 variable "domain" {
   description = "Fully Qualified Domain Name"
 }
@@ -140,6 +145,7 @@ variable "s3_cdn_url" {
 variable "cdn_url" {
   description = "Assets CDN URL. ex: https://cdn-assets.debtcollective.org"
 }
+
 
 variable "discourse_uploads_bucket_name" {
   description = "Uploads S3 bucket name"


### PR DESCRIPTION
**What:** Add monitoring to services with Cloudwatch

**Why:** To be notified in Slack in case machines resource utilization goes up.

**How:**

- Add monitoring to discourse and cluster modules
- Create CPU alarm for discourse module
- Create CPU and Memory alarm for cluster module