### PR TITLE
Add uptime monitoring and alerts

### DIFF
--- a/live/prod/services/discourse/vars.tf
+++ b/live/prod/services/discourse/vars.tf
@@ -67,3 +67,16 @@ variable "discourse_smtp_enable_start_tls" {
   description = "Discourse SMTP enable start TLS"
   default     = true
 }
+
+// StatusCake
+variable "statuscake_username" {
+  description = "StatusCake username"
+}
+
+variable "statuscake_apikey" {
+  description = "StatusCake API key"
+}
+
+variable "statuscake_contact_group_id" {
+  description = "StatusCake contact group id"
+}

--- a/modules/services/cluster/main.tf
+++ b/modules/services/cluster/main.tf
@@ -106,7 +106,9 @@ resource "aws_cloudwatch_metric_alarm" "high_cpu_usage" {
     ClusterName = aws_ecs_cluster.cluster.name
   }
 
-  alarm_actions = [var.slack_topic_arn]
+  alarm_actions             = [var.slack_topic_arn]
+  ok_actions                = [var.slack_topic_arn]
+  insufficient_data_actions = [var.slack_topic_arn]
 }
 
 resource "aws_cloudwatch_metric_alarm" "high_memory_usage" {
@@ -126,5 +128,29 @@ resource "aws_cloudwatch_metric_alarm" "high_memory_usage" {
     ClusterName = aws_ecs_cluster.cluster.name
   }
 
-  alarm_actions = [var.slack_topic_arn]
+  alarm_actions             = [var.slack_topic_arn]
+  ok_actions                = [var.slack_topic_arn]
+  insufficient_data_actions = [var.slack_topic_arn]
+}
+
+// Send alarm when ALB identifies unhealthy hosts
+resource "aws_cloudwatch_metric_alarm" "alb_unhealthyhosts" {
+  alarm_name          = "alarmname"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = "1"
+  metric_name         = "UnhealthyHostCount"
+  namespace           = "AWS/NetworkELB"
+  period              = "60"
+  statistic           = "Average"
+  threshold           = 0
+  alarm_description   = "Number of unhealthy nodes in Load Balancer"
+  actions_enabled     = "true"
+
+  alarm_actions             = [var.slack_topic_arn]
+  ok_actions                = [var.slack_topic_arn]
+  insufficient_data_actions = [var.slack_topic_arn]
+
+  dimensions = {
+    LoadBalancer = aws_lb.lb.arn_suffix
+  }
 }


### PR DESCRIPTION
**What:** Add uptime monitoring and alerts. Using statuscake.com

**Why:** To be notified if any of our services are down.

**How:**

- Create statuscake test pointing to discourse url
- Add ELB alarms in case any of our services is unhealthy
