### PR TITLE
add skylight.io integration for ruby apps

### DIFF
--- a/live/prod/services/discourse/main.tf
+++ b/live/prod/services/discourse/main.tf
@@ -51,8 +51,9 @@ module "discourse" {
   cdn_url            = aws_cloudfront_distribution.assets.domain_name
   discourse_hostname = local.fqdn
 
-  monitoring      = true
-  slack_topic_arn = local.slack_topic_arn
+  monitoring              = true
+  slack_topic_arn         = local.slack_topic_arn
+  skylight_authentication = var.skylight_authentication
 
   discourse_smtp_address  = var.discourse_smtp_address
   discourse_smtp_username = var.discourse_smtp_username

--- a/live/prod/services/discourse/vars.tf
+++ b/live/prod/services/discourse/vars.tf
@@ -80,3 +80,9 @@ variable "statuscake_apikey" {
 variable "statuscake_contact_group_id" {
   description = "StatusCake contact group id"
 }
+
+// Skylight
+variable "skylight_authentication" {
+  description = "skylight.io api key"
+  default     = ""
+}

--- a/live/prod/services/fundraising/main.tf
+++ b/live/prod/services/fundraising/main.tf
@@ -40,17 +40,18 @@ module "fundraising" {
   lb_listener_id = local.lb_listener_id
   vpc_id         = local.vpc_id
 
-  database_url           = local.database_url
-  discourse_login_url    = local.discourse_login_url
-  discourse_signup_url   = local.discourse_signup_url
-  redis_url              = local.redis_url
-  sso_cookie_name        = local.sso_cookie_name
-  sso_jwt_secret         = local.sso_jwt_secret
-  recaptcha_site_key     = var.recaptcha_site_key
-  recaptcha_secret_key   = var.recaptcha_secret_key
-  stripe_secret_key      = var.stripe_secret_key
-  stripe_publishable_key = var.stripe_publishable_key
-  sentry_dsn             = var.sentry_dsn
-  amplitude_api_key      = var.amplitude_api_key
-  ga_measurement_id      = var.ga_measurement_id
+  database_url            = local.database_url
+  discourse_login_url     = local.discourse_login_url
+  discourse_signup_url    = local.discourse_signup_url
+  redis_url               = local.redis_url
+  sso_cookie_name         = local.sso_cookie_name
+  sso_jwt_secret          = local.sso_jwt_secret
+  recaptcha_site_key      = var.recaptcha_site_key
+  recaptcha_secret_key    = var.recaptcha_secret_key
+  stripe_secret_key       = var.stripe_secret_key
+  stripe_publishable_key  = var.stripe_publishable_key
+  sentry_dsn              = var.sentry_dsn
+  amplitude_api_key       = var.amplitude_api_key
+  ga_measurement_id       = var.ga_measurement_id
+  skylight_authentication = var.skylight_authentication
 }

--- a/modules/services/discourse/main.tf
+++ b/modules/services/discourse/main.tf
@@ -74,6 +74,8 @@ resource "aws_instance" "discourse" {
         discourse_s3_upload_bucket     = var.discourse_uploads_bucket_name
         discourse_s3_backup_bucket     = var.discourse_backups_bucket_name
         discourse_s3_cdn_url           = var.cdn_url
+
+        skylight_authentication = var.skylight_authentication
       })
     )
 

--- a/modules/services/discourse/vars.tf
+++ b/modules/services/discourse/vars.tf
@@ -174,3 +174,8 @@ variable "discourse_aws_access_key_id" {
 variable "discourse_aws_secret_access_key" {
   description = "AWS access key secret for S3 uploads"
 }
+
+variable "skylight_authentication" {
+  description = "skylight.io api key"
+  default     = ""
+}

--- a/modules/services/discourse/web.yml
+++ b/modules/services/discourse/web.yml
@@ -26,6 +26,7 @@ env:
   DISCOURSE_SSO_JWT_SECRET: '${discourse_sso_jwt_secret}'
   LANG: en_US.UTF-8
   LETSENCRYPT_ACCOUNT_EMAIL: '${discourse_letsencrypt_account_email}'
+  SKYLIGHT_AUTHENTICATION: '${skylight_authentication}'
   USE_DB_S3_CONFIG: true
 expose:
   - '80:80'
@@ -58,6 +59,7 @@ hooks:
           - 'git clone https://github.com/debtcollective/discourse-debtcollective-signup-fields.git'
           - 'git clone https://github.com/debtcollective/discourse-debtcollective-collectives.git'
           - 'git clone https://github.com/debtcollective/discourse-sentry.git'
+          - 'git clone https://github.com/debtcollective/discourse-skylight.git'
     - exec:
         cd: $home
         cmd:

--- a/modules/services/fundraising/container_definitions.tf
+++ b/modules/services/fundraising/container_definitions.tf
@@ -101,6 +101,10 @@ module "container_definitions" {
       name  = "AMPLITUDE_API_KEY",
       value = var.amplitude_api_key
     },
+    {
+      name  = "SKYLIGHT_AUTHENTICATION",
+      value = var.skylight_authentication
+    },
   ]
 
   port_mappings = [

--- a/modules/services/fundraising/vars.tf
+++ b/modules/services/fundraising/vars.tf
@@ -95,3 +95,8 @@ variable "amplitude_api_key" {
 variable "ga_measurement_id" {
   description = "Google Analytics UA-XXXXX-Y"
 }
+
+variable "skylight_authentication" {
+  description = "Skylight.io api key"
+  default     = ""
+}


### PR DESCRIPTION
**What:** add [skylight.io](https://www.skylight.io/) integration for ruby apps

**Why:** to monitor the health and performance of our ruby apps.

**How:**

- pass `skylight_authentication` variable to fundraising and discourse modules
