### PR TITLE
dev(discourse): add mailchimp list plugin to web.yml

### DIFF
--- a/modules/services/discourse/web.yml
+++ b/modules/services/discourse/web.yml
@@ -60,6 +60,7 @@ hooks:
           - 'git clone https://github.com/debtcollective/discourse-debtcollective-collectives.git'
           - 'git clone https://github.com/debtcollective/discourse-sentry.git'
           - 'git clone https://github.com/debtcollective/discourse-skylight.git'
+          - 'git clone https://github.com/debtcollective/discourse-mailchimp-list.git'
     - exec:
         cd: $home
         cmd:


### PR DESCRIPTION
**What:**  add mailchimp list plugin to web.yml.

**Why:** To enable the plugin and sync signups to MailChimp.

**How:**

- Installing `https://github.com/debtcollective/discourse-mailchimp-list` on bootstrap
