### PR TITLE
dev(discourse): pass redis configuration

### DIFF
--- a/live/prod/services/discourse/dependencies.tf
+++ b/live/prod/services/discourse/dependencies.tf
@@ -70,6 +70,18 @@ data "terraform_remote_state" "s3" {
   }
 }
 
+data "terraform_remote_state" "redis" {
+  backend = "remote"
+
+  config = {
+    organization = local.remote_state_organization
+
+    workspaces = {
+      name = local.redis_remote_state_workspace
+    }
+  }
+}
+
 data "aws_ssm_parameter" "db_user" {
   name = data.terraform_remote_state.postgres_setup.outputs.discourse_db_user_ssm_key
 }
@@ -101,6 +113,9 @@ locals {
   db_port    = data.terraform_remote_state.postgres.outputs.db_port
   db_user    = data.aws_ssm_parameter.db_user.value
 
+  redis_host = data.terraform_remote_state.redis.outputs.host
+  redis_port = data.terraform_remote_state.redis.outputs.port
+
   ssh_key_pair_name     = data.terraform_remote_state.vpc.outputs.ssh_key_pair_name
   vpc_id                = data.terraform_remote_state.vpc.outputs.vpc_id
   subnet_id             = data.terraform_remote_state.vpc.outputs.public_subnet_ids[0]
@@ -114,6 +129,7 @@ locals {
   notify_slack_remote_state_workspace   = "${local.environment}-extras-notify-slack"
   postgres_remote_state_workspace       = "${local.environment}-postgres"
   postgres_setup_remote_state_workspace = "${local.environment}-postgres-setup"
+  redis_remote_state_workspace          = "${local.environment}-redis"
   remote_state_organization             = "debtcollective"
   s3_remote_state_workspace             = "${local.environment}-extras-s3"
   vpc_remote_state_workspace            = "${local.environment}-network"

--- a/live/prod/services/discourse/main.tf
+++ b/live/prod/services/discourse/main.tf
@@ -65,6 +65,9 @@ module "discourse" {
   discourse_db_password = local.db_pass
   discourse_sso_secret  = var.discourse_sso_secret
 
+  discourse_redis_host = local.redis_host
+  discourse_redis_port = local.redis_port
+
   discourse_reply_by_email_address = var.discourse_reply_by_email_address
   discourse_pop3_polling_username  = var.discourse_pop3_polling_username
   discourse_pop3_polling_password  = var.discourse_pop3_polling_password

--- a/modules/services/discourse/main.tf
+++ b/modules/services/discourse/main.tf
@@ -60,6 +60,9 @@ resource "aws_instance" "discourse" {
         discourse_db_username = var.discourse_db_username
         discourse_db_password = var.discourse_db_password
 
+        discourse_redis_host = var.discourse_redis_host
+        discourse_redis_port = var.discourse_redis_port
+
         discourse_developer_emails          = var.discourse_developer_emails
         discourse_hostname                  = var.discourse_hostname
         discourse_maxmind_license_key       = var.discourse_maxmind_license_key

--- a/modules/services/discourse/vars.tf
+++ b/modules/services/discourse/vars.tf
@@ -61,6 +61,16 @@ variable "discourse_db_password" {
   description = "Discourse database password"
 }
 
+// Redis Configuration
+variable "discourse_redis_host" {
+  description = "Discourse redis host"
+}
+
+variable "discourse_redis_port" {
+  description = "Discourse redis port"
+  default     = "6379"
+}
+
 variable "discourse_letsencrypt_account_email" {
   description = "email to setup Let's Encrypt"
   default     = "orlando@hashlabs.com"

--- a/modules/services/discourse/web.yml
+++ b/modules/services/discourse/web.yml
@@ -10,6 +10,8 @@ env:
   DISCOURSE_ENABLE_CORS: true
   DISCOURSE_HOSTNAME: '${discourse_hostname}'
   DISCOURSE_MAXMIND_LICENSE_KEY: '${discourse_maxmind_license_key}'
+  DISCOURSE_REDIS_HOST: '${discourse_redis_host}'
+  DISCOURSE_REDIS_PORT: '${discourse_redis_port}'
   DISCOURSE_S3_ACCESS_KEY_ID: '${discourse_s3_access_key_id}'
   DISCOURSE_S3_BACKUP_BUCKET: '${discourse_s3_backup_bucket}'
   DISCOURSE_S3_CDN_URL: '${discourse_s3_cdn_url}'
@@ -67,7 +69,6 @@ hooks:
           - 'apt-get update && apt-get -y install postgresql-client-11'
           - 'ln -s -f /usr/lib/postgresql/11/bin/pg_dump /usr/bin/pg_dump'
 templates:
-  - templates/redis.template.yml
   - templates/web.template.yml
   - templates/web.ratelimited.template.yml
   - templates/web.ssl.template.yml


### PR DESCRIPTION
**What:** Use elasticache redis instead of running redis inside the Discourse instance

**Why:** We want to reduce the load of our instance by moving redis out of the container

**How:**

- Pass redis configuration variables
- Remove redis template from web.yml