### PR TITLE
Enable Dispute tools workers

### DIFF
--- a/live/prod/data-stores/redis/main.tf
+++ b/live/prod/data-stores/redis/main.tf
@@ -24,7 +24,7 @@ module "redis" {
   stage  = "prod"
   name   = "redis"
 
-  alarm_cpu_threshold_percent  = 90
+  alarm_cpu_threshold_percent  = 85
   auth_token                   = null
   availability_zones           = data.aws_availability_zones.available.names
   engine_version               = "5.0.6"

--- a/live/prod/data-stores/redis/outputs.tf
+++ b/live/prod/data-stores/redis/outputs.tf
@@ -5,7 +5,7 @@ output "id" {
 
 output "security_group_id" {
   value       = module.redis.security_group_id
-  description = "Security group ID"
+  description = "Redis security group ID"
 }
 
 output "port" {
@@ -16,4 +16,9 @@ output "port" {
 output "host" {
   value       = module.redis.host
   description = "Redis host"
+}
+
+output "endpoint" {
+  value       = module.redis.endpoint
+  description = "Redis endpoint"
 }

--- a/live/prod/services/discourse/dependencies.tf
+++ b/live/prod/services/discourse/dependencies.tf
@@ -113,7 +113,7 @@ locals {
   db_port    = data.terraform_remote_state.postgres.outputs.db_port
   db_user    = data.aws_ssm_parameter.db_user.value
 
-  redis_host = data.terraform_remote_state.redis.outputs.host
+  redis_host = data.terraform_remote_state.redis.outputs.endpoint
   redis_port = data.terraform_remote_state.redis.outputs.port
 
   ssh_key_pair_name     = data.terraform_remote_state.vpc.outputs.ssh_key_pair_name

--- a/live/prod/services/dispute_tools/dependencies.tf
+++ b/live/prod/services/dispute_tools/dependencies.tf
@@ -100,7 +100,7 @@ locals {
   db_port     = data.terraform_remote_state.postgres.outputs.db_port
   db_username = data.aws_ssm_parameter.db_user.value
 
-  redis_host = data.terraform_remote_state.redis.outputs.host
+  redis_host = data.terraform_remote_state.redis.outputs.endpoint
   redis_port = data.terraform_remote_state.redis.outputs.port
 
   discourse_domain = data.terraform_remote_state.discourse.outputs.domain

--- a/live/prod/services/fundraising/dependencies.tf
+++ b/live/prod/services/fundraising/dependencies.tf
@@ -95,7 +95,7 @@ locals {
   discourse_login_url  = "${local.discourse_uri}/session/sso_cookies"
   discourse_signup_url = "${local.discourse_uri}/session/sso_cookies/signup"
   discourse_uri        = "https://${data.terraform_remote_state.discourse.outputs.domain}"
-  redis_host           = data.terraform_remote_state.redis.outputs.host
+  redis_host           = data.terraform_remote_state.redis.outputs.endpoint
   redis_port           = data.terraform_remote_state.redis.outputs.port
   redis_url            = "redis://${local.redis_host}:${local.redis_port}/0"
   sso_cookie_name      = data.terraform_remote_state.discourse.outputs.sso_cookie_name

--- a/modules/services/dispute_tools/container_definitions.tf
+++ b/modules/services/dispute_tools/container_definitions.tf
@@ -227,7 +227,7 @@ module "container_definition_workers" {
   container_image              = var.container_image
 
   // run workers
-  command = ["yarn start:workers"]
+  command = ["yarn", "start:workers"]
 
   environment = local.environment
 

--- a/modules/services/dispute_tools/container_definitions.tf
+++ b/modules/services/dispute_tools/container_definitions.tf
@@ -9,16 +9,7 @@ resource "aws_cloudwatch_log_group" "dispute_tools" {
   }
 }
 
-module "container_definitions" {
-  source = "git::https://github.com/cloudposse/terraform-aws-ecs-container-definition.git?ref=0.23.0"
-
-  container_name               = local.container_name
-  container_cpu                = null
-  container_memory             = null
-  container_memory_reservation = var.container_memory_reservation
-  essential                    = true
-  container_image              = var.container_image
-
+locals {
   environment = [
     {
       name  = "REDIS_HOST",
@@ -193,6 +184,19 @@ module "container_definitions" {
       value = var.google_analytics_ua
     }
   ]
+}
+
+module "container_definition_app" {
+  source = "git::https://github.com/cloudposse/terraform-aws-ecs-container-definition.git?ref=0.23.0"
+
+  container_name               = local.container_name
+  container_cpu                = null
+  container_memory             = null
+  container_memory_reservation = var.container_memory_reservation
+  essential                    = true
+  container_image              = var.container_image
+
+  environment = local.environment
 
   port_mappings = [
     {
@@ -201,6 +205,31 @@ module "container_definitions" {
       protocol      = "tcp"
     }
   ]
+
+  log_configuration = {
+    logDriver = "awslogs"
+    options = {
+      "awslogs-region" = data.aws_region.current.name
+      "awslogs-group"  = aws_cloudwatch_log_group.dispute_tools.name
+    }
+    secretOptions = null
+  }
+}
+
+module "container_definition_workers" {
+  source = "git::https://github.com/cloudposse/terraform-aws-ecs-container-definition.git?ref=0.23.0"
+
+  container_name               = "${local.container_name}-workers"
+  container_cpu                = null
+  container_memory             = null
+  container_memory_reservation = var.container_memory_reservation
+  essential                    = true
+  container_image              = var.container_image
+
+  // run workers
+  command = ["yarn start:workers"]
+
+  environment = local.environment
 
   log_configuration = {
     logDriver = "awslogs"

--- a/modules/services/dispute_tools/main.tf
+++ b/modules/services/dispute_tools/main.tf
@@ -40,7 +40,7 @@ resource "aws_lb_listener_rule" "dispute_tools" {
 // Create ECS task definition
 resource "aws_ecs_task_definition" "dispute_tools" {
   family                = "dispute_tools_${var.environment}"
-  container_definitions = module.container_definitions.json
+  container_definitions = "[${module.container_definition_app.json_map},${module.container_definition_workers.json_map}]"
 }
 
 // Create ECS service


### PR DESCRIPTION
**What:** Enable Dispute tools workers

**Why:** Related to https://github.com/debtcollective/dispute-tools/pull/195. This code enables this in our production env

**How:**

- Add a second container definition that runs `yarn start:workers`
- Fix redis outputs