### PR TITLE
Od/discourse secure uploads

### DIFF
--- a/live/prod/services/discourse/main.tf
+++ b/live/prod/services/discourse/main.tf
@@ -87,8 +87,6 @@ module "discourse" {
 
   discourse_sso_cookie_name = local.sso_cookie_name
 
-  volume_size = 30
-
   key_name        = local.ssh_key_pair_name
   subnet_id       = local.subnet_id
   security_groups = local.ec2_security_group_id

--- a/modules/services/discourse/cloud-config.yml
+++ b/modules/services/discourse/cloud-config.yml
@@ -28,7 +28,7 @@ runcmd:
   - echo "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDNmbm3AR92kE0igfVUJ9ZpY48oVS4Po+qH/3Jb6gF5NkHju+67Rf2MDkWQ4NzNp9yjlxL7LQk7c0dNuIR++GSS6dOLxixPXnLcYadqJF2h5qPV8RMNkOTuHR/zWPPEh77Xur8NoFtroBaCEMulfmGNUauyaNcV/KoK4/lxN53JItJaUt7OzdMU12jOdLsN985Neu2rPVIFv3eYty/rSEtTWkmIwVvVXkpFzoRTuNM+hYTPiAniHiON/h+wfNG5Ei4Lu/dGhy0NZRavF9TQTvLv/vsXQta6q+HzvF4IYsj2Dt0YBvNNL/uyO4mfA08U0jjnJCh7sjIHHrju9Q/i6r2sjNOoiynDnorUXAlUn++gkyFlksnRMLTxAKgvwYVsiQMjoOdIacp3Xwn11BaO6VsGf/9ub+P9B5XbG6gfwtVEWaag2FkWuIeFLF6qMwMAqpZFSG+lFO0iqFwxTO7MnwRTDxmiE13tfl3QHdciTc+qjtnNEPIhbJR0pQmtwZnnOmFdrxcb8phwdZOvUFA0OSXEL0VwvM6NaORpVxfotdWyZJ/JIhv1Jre0h+folgd1FIuNjZ7dVGQvbEwwVZDbsPHZNKbacHjD/sj9sK+rEll1RKTS8ReDBPWek1aoA9V80FSV6aMtI4/pVOXP6/1CBYEgB4nzZUBlzlS3uiCx9C6s4Q== orlando@hashlabs.com" >> /home/ubuntu/.ssh/authorized_keys
 
   # enable swap
-  - sudo fallocate -l 4G /swapfile
+  - sudo fallocate -l ${swap_size} /swapfile
   - ls -lh /swapfile
   - sudo chmod 600 /swapfile
   - sudo mkswap /swapfile

--- a/modules/services/discourse/main.tf
+++ b/modules/services/discourse/main.tf
@@ -42,6 +42,9 @@ resource "aws_instance" "discourse" {
   monitoring = var.monitoring
 
   user_data = templatefile("${path.module}/cloud-config.yml", {
+    # swap size
+    swap_size = var.swap_size
+
     # web.yml file
     web_yml_b64 = base64encode(
       templatefile("${path.module}/web.yml", {

--- a/modules/services/discourse/vars.tf
+++ b/modules/services/discourse/vars.tf
@@ -129,6 +129,11 @@ variable "security_groups" {
   description = "VPC Security Groups IDs to be used by the instance"
 }
 
+variable "swap_size" {
+  description = "Size of swap in GBs"
+  default     = "4G"
+}
+
 variable "instance_type" {
   description = "EC2 instance type"
   default     = "t3a.small"
@@ -136,7 +141,7 @@ variable "instance_type" {
 
 variable "volume_size" {
   description = "EBS block size"
-  default     = 20
+  default     = 30
 }
 
 variable "monitoring" {


### PR DESCRIPTION
**What:** Minor changes to the Discourse module to make it easier to resize the instance if it's needed.

**Why:** I had to make some changes to run a task that was pending to make our uploads in private messages secure (https://meta.discourse.org/t/secure-media-uploads/140017/44?u=eatcodetravel). I had to adjust the size of the instance (from a t3a.small to a t3a.medium) but just to run the task, now is back to t3a.small

**How:**

- Expose swap memory variable in Discourse module
