### PR TITLE
Od/remove stripe tools

### DIFF
--- a/live/prod/services/dispute_tools/main.tf
+++ b/live/prod/services/dispute_tools/main.tf
@@ -53,6 +53,7 @@ module "dispute_tools" {
   contact_email        = var.contact_email
   disputes_bcc_address = var.disputes_bcc_address
   sender_email         = var.sender_email
+  donate_url           = var.donate_url
 
   sso_cookie_name          = "_dispute_tools__${local.environment}"
   landing_page_url         = "https://debtcollective.org"
@@ -76,8 +77,6 @@ module "dispute_tools" {
   doe_disclosure_state           = var.doe_disclosure_state
   doe_disclosure_zip             = var.doe_disclosure_zip
 
-  stripe_private       = var.stripe_private
-  stripe_publishable   = var.stripe_publishable
   loggly_api_key       = var.loggly_api_key
   sentry_endpoint      = var.sentry_endpoint
   google_maps_api_key  = var.google_maps_api_key

--- a/live/prod/services/dispute_tools/vars.tf
+++ b/live/prod/services/dispute_tools/vars.tf
@@ -43,12 +43,9 @@ variable "loggly_api_key" {
   description = "Loggly API key"
 }
 
-variable "stripe_private" {
-  description = "Stripe private key"
-}
-
-variable "stripe_publishable" {
-  description = "Stripe shared key"
+variable "donate_url" {
+  description = "Donate URL"
+  default     = "https://membership.debtcollective.org"
 }
 
 variable "google_maps_api_key" {

--- a/modules/services/dispute_tools/container_definitions.tf
+++ b/modules/services/dispute_tools/container_definitions.tf
@@ -92,14 +92,6 @@ locals {
       value = var.sentry_endpoint
     },
     {
-      name  = "STRIPE_PRIVATE",
-      value = var.stripe_private
-    },
-    {
-      name  = "STRIPE_PUBLISHABLE",
-      value = var.stripe_publishable
-    },
-    {
       name  = "GMAPS_KEY",
       value = var.google_maps_api_key
     },

--- a/modules/services/dispute_tools/container_definitions.tf
+++ b/modules/services/dispute_tools/container_definitions.tf
@@ -174,6 +174,10 @@ locals {
     {
       name  = "GOOGLE_ANALYTICS_UA",
       value = var.google_analytics_ua
+    },
+    {
+      name  = "DONATE_URL",
+      value = var.donate_url
     }
   ]
 }

--- a/modules/services/dispute_tools/vars.tf
+++ b/modules/services/dispute_tools/vars.tf
@@ -95,14 +95,6 @@ variable "loggly_api_key" {
   description = "Loggly API key"
 }
 
-variable "stripe_private" {
-  description = "Stripe private key"
-}
-
-variable "stripe_publishable" {
-  description = "Stripe shared key"
-}
-
 variable "google_maps_api_key" {
   description = "Google maps API key"
 }

--- a/modules/services/dispute_tools/vars.tf
+++ b/modules/services/dispute_tools/vars.tf
@@ -95,6 +95,11 @@ variable "loggly_api_key" {
   description = "Loggly API key"
 }
 
+variable "donate_url" {
+  description = "Donate URL"
+  default     = "https://membership.debtcollective.org"
+}
+
 variable "google_maps_api_key" {
   description = "Google maps API key"
 }


### PR DESCRIPTION
**What:** Remove stripe variables from tools module

**Why:** We removed the stripe dependency in this PR https://github.com/debtcollective/dispute-tools/pull/197 

**How:**

- Remove stripe variables
- Pass `DONATE_URL` default to the module (defaults to membership.debtcollective.org)