### PR TITLE
dev(discourse): add discourse ads plugin

### DIFF
--- a/modules/services/discourse/web.yml
+++ b/modules/services/discourse/web.yml
@@ -63,6 +63,8 @@ hooks:
           - 'git clone https://github.com/debtcollective/discourse-sentry.git'
           - 'git clone https://github.com/debtcollective/discourse-skylight.git'
           - 'git clone https://github.com/debtcollective/discourse-mailchimp-list.git'
+          - 'git clone https://github.com/discourse/discourse-adplugin.git'
+
     - exec:
         cd: $home
         cmd:


### PR DESCRIPTION
**What:** add [discourse ads plugin](https://github.com/discourse/discourse-adplugin)

**Why:** we want to run in-house ads in our community, this plugin will allow us to do that.

**How:**

- adding discourse ads plugin to web.yml
