### PR TITLE
feat(campaign-api): pass mailchimp variables

### DIFF
--- a/live/prod/services/campaign_api/main.tf
+++ b/live/prod/services/campaign_api/main.tf
@@ -49,6 +49,9 @@ module "campaign_api" {
   discourse_login_url    = local.discourse_login_url
   discourse_signup_url   = local.discourse_signup_url
   introspection          = var.introspection
+  mailchimp_api_key      = var.mailchimp_api_key
+  mailchimp_list_id      = var.mailchimp_list_id
+  mailchimp_tag          = var.mailchimp_tag
   playground             = var.playground
   sentry_dsn             = var.sentry_dsn
   sso_cookie_name        = local.sso_cookie_name

--- a/live/prod/services/campaign_api/vars.tf
+++ b/live/prod/services/campaign_api/vars.tf
@@ -23,3 +23,15 @@ variable "playground" {
   description = "GraphQL playground"
   default     = false
 }
+
+variable "mailchimp_api_key" {
+  description = "Mailchimp API key"
+}
+
+variable "mailchimp_list_id" {
+  description = "Mailchimp list id"
+}
+
+variable "mailchimp_tag" {
+  description = "Mailchimp tag"
+}

--- a/modules/services/campaign_api/container_definitions.tf
+++ b/modules/services/campaign_api/container_definitions.tf
@@ -76,6 +76,18 @@ module "container_definitions" {
       name  = "DISCOURSE_API_URL",
       value = var.discourse_api_url
     },
+    {
+      name  = "MAILCHIMP_API_KEY",
+      value = var.mailchimp_api_key
+    },
+    {
+      name  = "MAILCHIMP_LIST_ID",
+      value = var.mailchimp_list_id
+    },
+    {
+      name  = "MAILCHIMP_TAG",
+      value = var.mailchimp_tag
+    },
   ]
 
   port_mappings = [

--- a/modules/services/campaign_api/vars.tf
+++ b/modules/services/campaign_api/vars.tf
@@ -90,3 +90,15 @@ variable "discourse_api_key" {
 variable "discourse_api_url" {
   description = "Discourse API URL"
 }
+
+variable "mailchimp_api_key" {
+  description = "Mailchimp API key"
+}
+
+variable "mailchimp_list_id" {
+  description = "Mailchimp list id"
+}
+
+variable "mailchimp_tag" {
+  description = "Mailchimp tag"
+}


### PR DESCRIPTION
**What:** pass mailchimp variables

**Why:** Related to https://github.com/debtcollective/campaign-api/pull/42

**How:** 

- Pass MailChimp variables to campaign API service