### PR TITLE
dev: remove signup-fields plugin

### DIFF
--- a/modules/services/discourse/web.yml
+++ b/modules/services/discourse/web.yml
@@ -57,7 +57,6 @@ hooks:
           - 'git clone https://github.com/debtcollective/discourse-debtcollective-wizards.git'
           - 'git clone https://github.com/debtcollective/discourse-debtcollective-private-message.git'
           - 'git clone https://github.com/debtcollective/discourse-debtcollective-sso.git'
-          - 'git clone https://github.com/debtcollective/discourse-debtcollective-signup-fields.git'
           - 'git clone https://github.com/debtcollective/discourse-debtcollective-collectives.git'
           - 'git clone https://github.com/debtcollective/discourse-sentry.git'
           - 'git clone https://github.com/debtcollective/discourse-skylight.git'


### PR DESCRIPTION
**What:** remove signup-fields plugin

**Why:** This plugin was merged with discourse-debtcollective-theme (front-end) and discourse-debtcollective-sso (back-end)

**How:**

- Remove plugin from web.yml