### PR TITLE
feat(discourse-plugins): install discourse chat integration plugin

### DIFF
--- a/modules/services/discourse/web.yml
+++ b/modules/services/discourse/web.yml
@@ -62,6 +62,7 @@ hooks:
           - 'git clone https://github.com/debtcollective/discourse-skylight.git'
           - 'git clone https://github.com/debtcollective/discourse-mailchimp-list.git'
           - 'git clone https://github.com/discourse/discourse-adplugin.git'
+          - 'git clone https://github.com/discourse/discourse-chat-integration.git'
 
     - exec:
         cd: $home


### PR DESCRIPTION
Asana ticket: https://app.asana.com/0/1168997577035609/1183391677913093/f

**What:**
Install discourse chat integration plugin

**Why:**
In order to sync slack with discourse, it is required to install this plugin in our discourse instance

**How:**
By adding the plugin at the `yml` file
