### PR TITLE
Add S3 integration to Ghost

### DIFF
--- a/live/prod/services/ghost/dependencies.tf
+++ b/live/prod/services/ghost/dependencies.tf
@@ -79,4 +79,6 @@ locals {
   mysql_setup_remote_state_workspace = "${local.environment}-mysql-setup"
   remote_state_organization          = "debtcollective"
   vpc_remote_state_workspace         = "${local.environment}-network"
+
+  uploads_bucket_name = "ghost-uploads-${local.environment}"
 }

--- a/live/prod/services/ghost/iam.tf
+++ b/live/prod/services/ghost/iam.tf
@@ -1,0 +1,51 @@
+// User for Ghost s3 uploads
+resource "aws_iam_user" "ghost" {
+  name = "ghost_uploads_${local.environment}"
+  path = "/terraform/${local.environment}/ghost/"
+
+  tags = {
+    Terraform   = true
+    Environment = local.environment
+  }
+}
+
+data "aws_iam_policy_document" "ghost" {
+  statement {
+    sid = "1"
+
+    actions = [
+      "s3:List*",
+      "s3:Get*",
+      "s3:Put*",
+      "s3:AbortMultipartUpload",
+      "s3:DeleteObject",
+    ]
+
+    resources = [
+      aws_s3_bucket.uploads.arn,
+      "${aws_s3_bucket.uploads.arn}/*",
+    ]
+  }
+
+  statement {
+    actions = [
+      "s3:ListAllMyBuckets",
+      "s3:HeadBucket",
+    ]
+
+    resources = [
+      "*",
+    ]
+  }
+}
+
+resource "aws_iam_user_policy" "user_policy" {
+  name_prefix = "GhostPolicy${title(local.environment)}"
+  user        = aws_iam_user.ghost.name
+
+  policy = data.aws_iam_policy_document.ghost.json
+}
+
+resource "aws_iam_access_key" "ghost" {
+  user = aws_iam_user.ghost.name
+}

--- a/live/prod/services/ghost/main.tf
+++ b/live/prod/services/ghost/main.tf
@@ -21,7 +21,7 @@ data "aws_route53_zone" "primary" {
 
 resource "aws_route53_record" "ghost" {
   zone_id = data.aws_route53_zone.primary.zone_id
-  name    = "ghost"
+  name    = "blog"
   type    = "A"
 
   alias {
@@ -30,12 +30,6 @@ resource "aws_route53_record" "ghost" {
     evaluate_target_health = true
   }
 }
-
-// create S3 bucket
-
-// create AIM role
-
-// Check cloudfront dependencies
 
 module "ghost" {
   source      = "../../../../modules/services/ghost"

--- a/live/prod/services/ghost/main.tf
+++ b/live/prod/services/ghost/main.tf
@@ -31,6 +31,12 @@ resource "aws_route53_record" "ghost" {
   }
 }
 
+// create S3 bucket
+
+// create AIM role
+
+// Check cloudfront dependencies
+
 module "ghost" {
   source      = "../../../../modules/services/ghost"
   environment = local.environment
@@ -45,9 +51,15 @@ module "ghost" {
   db_name             = local.db_name
   db_password_ssm_key = local.db_password_ssm_key
   db_username_ssm_key = local.db_username_ssm_key
+
   mail_from           = var.mail_from
   mail_host           = var.mail_host
   mail_pass           = var.mail_pass
   mail_port           = var.mail_port
   mail_user           = var.mail_user
+
+  s3_access_key_id = aws_iam_access_key.ghost.id
+  s3_secret_access_key = aws_iam_access_key.ghost.secret
+  s3_bucket = aws_s3_bucket.uploads.id
+  s3_region = aws_s3_bucket.uploads.region
 }

--- a/live/prod/services/ghost/s3.tf
+++ b/live/prod/services/ghost/s3.tf
@@ -1,0 +1,44 @@
+// S3 buckets and permissions
+resource "aws_s3_bucket" "uploads" {
+  bucket = local.uploads_bucket_name
+  acl    = "private"
+
+  cors_rule {
+    allowed_headers = ["Authorization"]
+    allowed_methods = ["GET", "HEAD"]
+    allowed_origins = ["*"]
+    max_age_seconds = 3000
+  }
+
+  lifecycle {
+    prevent_destroy = true
+  }
+
+  tags = {
+    Terraform   = true
+    Name        = local.uploads_bucket_name
+    Environment = local.environment
+  }
+}
+
+data "aws_iam_policy_document" "uploads" {
+  statement {
+    actions = [
+      "s3:GetObject",
+    ]
+
+    resources = [
+      "${aws_s3_bucket.uploads.arn}/*"
+    ]
+
+    principals {
+      type        = "*"
+      identifiers = ["*"]
+    }
+  }
+}
+
+resource "aws_s3_bucket_policy" "uploads" {
+  bucket = aws_s3_bucket.uploads.id
+  policy = data.aws_iam_policy_document.uploads.json
+}

--- a/modules/services/ghost/container_definitions.tf
+++ b/modules/services/ghost/container_definitions.tf
@@ -61,6 +61,26 @@ module "container_definitions" {
       value = var.mail_pass
     },
     {
+      name  = "storage__active",
+      value = "ghost-s3"
+    },
+    {
+      name  = "storage__ghost-s3__accessKeyId",
+      value = var.s3_access_key_id
+    },
+    {
+      name  = "storage__ghost-s3__secretAccessKey",
+      value = var.s3_secret_access_key
+    },
+    {
+      name  = "storage__ghost-s3__bucket",
+      value = var.s3_bucket
+    },
+    {
+      name  = "storage__ghost-s3__region",
+      value = var.s3_region
+    },
+    {
       name  = "url",
       value = "https://${var.domain}"
     },

--- a/modules/services/ghost/vars.tf
+++ b/modules/services/ghost/vars.tf
@@ -4,7 +4,7 @@ variable "environment" {
 
 variable "container_image" {
   description = "Docker image name"
-  default     = "debtcollective/ghost:latest"
+  default     = "debtcollective/ghost-s3:latest"
 }
 
 variable "container_memory_reservation" {

--- a/modules/services/ghost/vars.tf
+++ b/modules/services/ghost/vars.tf
@@ -4,12 +4,12 @@ variable "environment" {
 
 variable "container_image" {
   description = "Docker image name"
-  default     = "ghost:latest"
+  default     = "debtcollective/ghost:latest"
 }
 
 variable "container_memory_reservation" {
   description = "Memory reservation for containers"
-  default     = 1024
+  default     = 512
 }
 
 variable "vpc_id" {
@@ -82,4 +82,20 @@ variable "mail_pass" {
 
 variable "mail_from" {
   description = "Mail default from address"
+}
+
+variable "s3_access_key_id" {
+  description = "AWS S3 Access key id"
+}
+
+variable "s3_secret_access_key" {
+  description = "AWS S3 Secret access key"
+}
+
+variable "s3_bucket" {
+  description = "AWS S3 Bucket"
+}
+
+variable "s3_region" {
+  description = "AWS S3 bucket region"
 }


### PR DESCRIPTION
**What:** Add S3 integration to Ghost

We are using a custom image for ghost, but we are just extending the official one with just the S3 integration so this shouldn't be a maintainability issue https://github.com/debtcollective/docker-ghost-s3.

This is available on https://blog.debtcollective.org

**Why:** Related to https://app.asana.com/0/1168997577035609/1180034130410203

**How:**

- Create Docker Ghost image with S3 plugin installed
- Add the infra code to create the resources on AWS and configure the Ghost integration with S3
