### PR TITLE
dev: make nginx serve .map files with application/json mime type

### DIFF
--- a/modules/services/discourse/web.yml
+++ b/modules/services/discourse/web.yml
@@ -69,6 +69,14 @@ hooks:
         cmd:
           - 'apt-get update && apt-get -y install postgresql-client-11'
           - 'ln -s -f /usr/lib/postgresql/11/bin/pg_dump /usr/bin/pg_dump'
+run:
+  - replace:
+      filename: "/etc/nginx/conf.d/discourse.conf"
+      from: /types.*\{[^\}]+\}/
+      to: "types {
+        text/csv csv;
+        application/json map;
+      }"
 templates:
   - templates/web.template.yml
   - templates/web.ratelimited.template.yml


### PR DESCRIPTION
**What:** make nginx serve .map files with application/json mime type

**Why:** Related to https://app.asana.com/0/1168997577035609/1174554751595161

**How:**

Discourse already generates and makes source maps available for each file, if you open a file you will see the `sourceMappingURL=` directive at the end. ex. https://d16zv78c963s69.cloudfront.net/assets/ember_jquery-1ed3f3559e6f967733b4088aa729ff7039dff2c09c5a5f787a214b016f58aabc.js

Source maps are being rendered by the chrome developer tool without issue, but in Sentry, these don't work. I'm guessing this is related to the mime-type which .map files are being served by Nginx, .map files return `application/octet-stream` instead of `application/json` they have in Rails (you can check this by using `file --mime-type example.js`)

This code adds a map files to the Nginx `type` directive, so we serve these files with mime-type set to `application/json`

In any case I'll reach out @sentry support