### PR TITLE
feat(ghost): add cdn with cloudfront

### DIFF
--- a/live/prod/services/ghost/cloudfront.tf
+++ b/live/prod/services/ghost/cloudfront.tf
@@ -1,0 +1,85 @@
+# cloudfront requires certificate from us-east-1
+provider "aws" {
+  version = "~> 2.0"
+  region  = "us-east-1"
+  alias   = "use1"
+}
+
+data "aws_acm_certificate" "domain" {
+  provider = aws.use1
+  domain   = local.acm_certificate_domain
+  statuses = ["ISSUED"]
+}
+
+resource "aws_cloudfront_origin_access_identity" "uploads" {
+  comment = "ghost-${local.environment} uploads origin"
+}
+
+resource "aws_cloudfront_distribution" "uploads" {
+  origin {
+    domain_name = aws_s3_bucket.uploads.bucket_domain_name
+    origin_id   = local.s3_origin_id
+
+    s3_origin_config {
+      origin_access_identity = aws_cloudfront_origin_access_identity.uploads.cloudfront_access_identity_path
+    }
+  }
+
+  enabled             = true
+  is_ipv6_enabled     = true
+  default_root_object = "index.html"
+  price_class         = "PriceClass_200"
+
+  aliases = ["${local.cdn_alias}.${local.domain}"]
+
+  default_cache_behavior {
+    allowed_methods  = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
+    cached_methods   = ["GET", "HEAD"]
+    target_origin_id = local.s3_origin_id
+
+    forwarded_values {
+      query_string = false
+
+      cookies {
+        forward = "none"
+      }
+    }
+
+    viewer_protocol_policy = "allow-all"
+    min_ttl                = 0
+    default_ttl            = 3600
+    max_ttl                = 86400
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  // We are using a custom alias
+  // We need to provide a SSL certificate for that alias
+  viewer_certificate {
+    ssl_support_method  = "sni-only"
+    acm_certificate_arn = data.aws_acm_certificate.domain.arn
+  }
+
+  tags = {
+    Terraform   = true
+    Name        = local.s3_origin_id
+    Environment = local.environment
+    Cache       = true
+  }
+}
+
+resource "aws_route53_record" "cdn" {
+  zone_id = data.aws_route53_zone.primary.zone_id
+  name    = local.cdn_alias
+  type    = "A"
+
+  alias {
+    name                   = aws_cloudfront_distribution.uploads.domain_name
+    zone_id                = aws_cloudfront_distribution.uploads.hosted_zone_id
+    evaluate_target_health = false
+  }
+}

--- a/live/prod/services/ghost/dependencies.tf
+++ b/live/prod/services/ghost/dependencies.tf
@@ -80,5 +80,9 @@ locals {
   remote_state_organization          = "debtcollective"
   vpc_remote_state_workspace         = "${local.environment}-network"
 
-  uploads_bucket_name = "ghost-uploads-${local.environment}"
+  acm_certificate_domain = "*.debtcollective.org"
+  cdn_alias              = "ghost-cdn-${local.environment}"
+  domain                 = "debtcollective.org"
+  s3_origin_id           = "ghost-${local.environment}"
+  uploads_bucket_name    = "ghost-uploads-${local.environment}"
 }

--- a/live/prod/services/ghost/main.tf
+++ b/live/prod/services/ghost/main.tf
@@ -46,14 +46,15 @@ module "ghost" {
   db_password_ssm_key = local.db_password_ssm_key
   db_username_ssm_key = local.db_username_ssm_key
 
-  mail_from           = var.mail_from
-  mail_host           = var.mail_host
-  mail_pass           = var.mail_pass
-  mail_port           = var.mail_port
-  mail_user           = var.mail_user
+  mail_from = var.mail_from
+  mail_host = var.mail_host
+  mail_pass = var.mail_pass
+  mail_port = var.mail_port
+  mail_user = var.mail_user
 
-  s3_access_key_id = aws_iam_access_key.ghost.id
+  s3_access_key_id     = aws_iam_access_key.ghost.id
   s3_secret_access_key = aws_iam_access_key.ghost.secret
-  s3_bucket = aws_s3_bucket.uploads.id
-  s3_region = aws_s3_bucket.uploads.region
+  s3_bucket            = aws_s3_bucket.uploads.id
+  s3_region            = aws_s3_bucket.uploads.region
+  cdn_url              = "https://${aws_route53_record.cdn.fqdn}"
 }

--- a/modules/services/ghost/container_definitions.tf
+++ b/modules/services/ghost/container_definitions.tf
@@ -81,6 +81,10 @@ module "container_definitions" {
       value = var.s3_region
     },
     {
+      name  = "storage__ghost-s3__assetHost",
+      value = var.cdn_url
+    },
+    {
       name  = "url",
       value = "https://${var.domain}"
     },

--- a/modules/services/ghost/vars.tf
+++ b/modules/services/ghost/vars.tf
@@ -61,7 +61,7 @@ variable "db_name" {
 
 variable "mail_transport" {
   description = "Mail transport protocol"
-  default = "SMTP"
+  default     = "SMTP"
 }
 
 variable "mail_host" {
@@ -98,4 +98,8 @@ variable "s3_bucket" {
 
 variable "s3_region" {
   description = "AWS S3 bucket region"
+}
+
+variable "cdn_url" {
+  description = "Cloudfront distribution URL to serve assets via CDN"
 }


### PR DESCRIPTION
**What:** add CDN with CloudFront.

This is already deployed and it's working on Production. ex. https://ghost-cdn-prod.debtcollective.org/2020/07/annb_DC1-3.jpg

**Why:** Closes https://app.asana.com/0/1168997577035609/1184093250242969

**How:**

- Create CloudFront distribution and link it to the Ghost S3 plugin, instructions here https://github.com/colinmeinke/ghost-storage-adapter-s3#cloudfront
