### PR TITLE
feat(fundraising): rename ecs service and tasks to membership

### DIFF
--- a/modules/services/fundraising/main.tf
+++ b/modules/services/fundraising/main.tf
@@ -65,13 +65,13 @@ resource "aws_lb_listener_rule" "fundraising" {
 
 // Create ECS task definition
 resource "aws_ecs_task_definition" "fundraising" {
-  family                = "fundraising_${var.environment}"
+  family                = "membership_${var.environment}"
   container_definitions = module.container_definitions.json
 }
 
 // Create ECS service
 resource "aws_ecs_service" "fundraising" {
-  name            = "fundraising"
+  name            = "membership"
   cluster         = var.ecs_cluster_id
   task_definition = aws_ecs_task_definition.fundraising.arn
   desired_count   = var.desired_count

--- a/modules/services/fundraising/vars.tf
+++ b/modules/services/fundraising/vars.tf
@@ -4,7 +4,7 @@ variable "environment" {
 
 variable "container_image" {
   description = "Docker image name"
-  default     = "debtcollective/fundraising:latest"
+  default     = "debtcollective/membership:latest"
 }
 
 variable "container_memory_reservation" {


### PR DESCRIPTION
**What:** rename ecs service and tasks to membership

**Why:** Related to https://app.asana.com/0/1168997577035609/1186563322147171

**How:**

- Rename fundraising to membership in some parts of infra repo. There are other references to fundraising that need to be changed and this will be worked on this task https://app.asana.com/0/1159164196409129/1186758986049745
