### PR TITLE
dev: change donate url

### DIFF
--- a/live/prod/services/dispute_tools/vars.tf
+++ b/live/prod/services/dispute_tools/vars.tf
@@ -45,7 +45,7 @@ variable "loggly_api_key" {
 
 variable "donate_url" {
   description = "Donate URL"
-  default     = "https://membership.debtcollective.org"
+  default     = "https://debtcollective.org/donate"
 }
 
 variable "google_maps_api_key" {

--- a/live/prod/services/membership/main.tf
+++ b/live/prod/services/membership/main.tf
@@ -47,7 +47,7 @@ module "membership" {
   discourse_url           = local.discourse_url
   discourse_username      = var.discourse_username
   discourse_api_key       = var.discourse_api_key
-  member_hub_url          = var.member_hub_url
+  home_page_url           = var.home_page_url
   cors_origins            = var.cors_origins
   cookie_domain           = var.cookie_domain
   ga_measurement_id       = var.ga_measurement_id

--- a/live/prod/services/membership/vars.tf
+++ b/live/prod/services/membership/vars.tf
@@ -7,8 +7,8 @@ variable "discourse_api_key" {
   description = "Discourse API key"
 }
 
-variable "member_hub_url" {
-  description = "Member Hub URL"
+variable "home_page_url" {
+  description = "Home page URL"
 }
 
 variable "cors_origins" {

--- a/modules/services/dispute_tools/vars.tf
+++ b/modules/services/dispute_tools/vars.tf
@@ -97,7 +97,7 @@ variable "loggly_api_key" {
 
 variable "donate_url" {
   description = "Donate URL"
-  default     = "https://membership.debtcollective.org"
+  default     = "https://debtcollective.org/donate"
 }
 
 variable "google_maps_api_key" {

--- a/modules/services/membership/container_definitions.tf
+++ b/modules/services/membership/container_definitions.tf
@@ -94,8 +94,8 @@ module "container_definitions" {
       value = var.discourse_api_key
     },
     {
-      name  = "MEMBER_HUB_URL",
-      value = var.member_hub_url
+      name  = "HOME_PAGE_URL",
+      value = var.home_page_url
     },
     {
       name  = "CORS_ORIGINS",

--- a/modules/services/membership/vars.tf
+++ b/modules/services/membership/vars.tf
@@ -105,7 +105,7 @@ variable "discourse_admin_role" {
   default     = "dispute_pro"
 }
 
-variable "member_hub_url" {
+variable "home_page_url" {
   description = "Member Hub URL"
 }
 


### PR DESCRIPTION
**What:** change donate url

**Why:** Related to the post-release fixes milestone

**How:**

- Change donation url from membership.debtcollective.com to debtcollective.org/donate