### PR TITLE
Add chatwoot to our infra

### DIFF
--- a/live/test/data-stores/postgres/main.tf
+++ b/live/test/data-stores/postgres/main.tf
@@ -25,4 +25,5 @@ module "postgres" {
   vpc_security_group_ids = local.vpc_security_group_ids
   allocated_storage      = 5
   skip_final_snapshot    = true
+  engine_version         = "11.9"
 }

--- a/live/test/data-stores/postgres/setup/chatwoot.tf
+++ b/live/test/data-stores/postgres/setup/chatwoot.tf
@@ -1,0 +1,62 @@
+// Generate random username and password
+resource "random_string" "chatwoot_db_user" {
+  length  = 24
+  special = false
+}
+
+resource "random_password" "chatwoot_db_pass" {
+  length           = 24
+  special          = true
+  min_special      = 1
+  override_special = "~*^+"
+}
+
+// Store both in SSM
+resource "aws_ssm_parameter" "chatwoot_db_user" {
+  name  = "/${local.environment}/services/chatwoot/db_user"
+  type  = "String"
+  value = "chatwoot_${random_string.chatwoot_db_user.result}"
+}
+
+resource "aws_ssm_parameter" "chatwoot_db_pass" {
+  name  = "/${local.environment}/services/chatwoot/db_pass"
+  type  = "SecureString"
+  value = random_password.chatwoot_db_pass.result
+}
+
+// Create postgres role and db
+resource "postgresql_role" "chatwoot" {
+  login               = true
+  name                = aws_ssm_parameter.chatwoot_db_user.value
+  password            = aws_ssm_parameter.chatwoot_db_pass.value
+  roles               = [local.master_db_user]
+  skip_reassign_owned = true
+}
+
+resource "postgresql_database" "chatwoot" {
+  name       = "chatwoot_${local.environment}"
+  owner      = local.master_db_user
+  lc_collate = "en_US.UTF-8"
+  lc_ctype   = "en_US.UTF-8"
+  encoding   = "UTF8"
+}
+
+resource "postgresql_default_privileges" "chatwoot_tables" {
+  database    = postgresql_database.chatwoot.name
+  depends_on  = [postgresql_database.chatwoot, postgresql_role.chatwoot]
+  object_type = "table"
+  owner       = local.master_db_user
+  privileges  = local.table_privileges
+  role        = postgresql_role.chatwoot.name
+  schema      = "public"
+}
+
+resource "postgresql_default_privileges" "chatwoot_sequence" {
+  database    = postgresql_database.chatwoot.name
+  depends_on  = [postgresql_database.chatwoot, postgresql_role.chatwoot]
+  object_type = "sequence"
+  owner       = local.master_db_user
+  privileges  = local.sequence_privileges
+  role        = postgresql_role.chatwoot.name
+  schema      = "public"
+}

--- a/live/test/data-stores/postgres/setup/dependencies.tf
+++ b/live/test/data-stores/postgres/setup/dependencies.tf
@@ -19,7 +19,8 @@ data "aws_ssm_parameter" "master_db_pass" {
 }
 
 locals {
-  environment                     = "test"
+  environment = "test"
+
   postgres_remote_state_workspace = "test-postgres"
   remote_state_organization       = "debtcollective"
   master_db_user                  = data.aws_ssm_parameter.master_db_user.value

--- a/live/test/data-stores/postgres/setup/outputs.tf
+++ b/live/test/data-stores/postgres/setup/outputs.tf
@@ -25,3 +25,16 @@ output "membership_db_name" {
   value = postgresql_database.membership.name
 
 }
+
+# Chatwoot
+output "chatwoot_db_user_ssm_key" {
+  value = aws_ssm_parameter.chatwoot_db_user.name
+}
+
+output "chatwoot_db_pass_ssm_key" {
+  value = aws_ssm_parameter.chatwoot_db_pass.name
+}
+
+output "chatwoot_db_name" {
+  value = postgresql_database.chatwoot.name
+}

--- a/live/test/services/chatwoot/dependencies.tf
+++ b/live/test/services/chatwoot/dependencies.tf
@@ -1,0 +1,78 @@
+data "terraform_remote_state" "vpc" {
+  backend = "remote"
+
+  config = {
+    organization = local.remote_state_organization
+
+    workspaces = {
+      name = local.vpc_remote_state_workspace
+    }
+  }
+}
+
+data "terraform_remote_state" "cluster" {
+  backend = "remote"
+
+  config = {
+    organization = local.remote_state_organization
+
+    workspaces = {
+      name = local.cluster_remote_state_workspace
+    }
+  }
+}
+
+data "terraform_remote_state" "postgres" {
+  backend = "remote"
+
+  config = {
+    organization = local.remote_state_organization
+
+    workspaces = {
+      name = local.postgres_remote_state_workspace
+    }
+  }
+}
+
+data "terraform_remote_state" "postgres_setup" {
+  backend = "remote"
+
+  config = {
+    organization = local.remote_state_organization
+
+    workspaces = {
+      name = local.postgres_setup_remote_state_workspace
+    }
+  }
+}
+
+data "aws_ssm_parameter" "db_user" {
+  name = data.terraform_remote_state.postgres_setup.outputs.chatwoot_db_user_ssm_key
+}
+
+data "aws_ssm_parameter" "db_pass" {
+  name = data.terraform_remote_state.postgres_setup.outputs.chatwoot_db_pass_ssm_key
+}
+
+locals {
+  environment = "prod"
+
+  db_host     = data.terraform_remote_state.postgres.outputs.db_address
+  db_name     = data.terraform_remote_state.postgres_setup.outputs.chatwoot_db_name
+  db_password = data.aws_ssm_parameter.db_pass.value
+  db_port     = data.terraform_remote_state.postgres.outputs.db_port
+  db_username = data.aws_ssm_parameter.db_user.value
+
+  ecs_cluster_id = data.terraform_remote_state.cluster.outputs.ecs_cluster_id
+  lb_dns_name    = data.terraform_remote_state.cluster.outputs.lb_dns_name
+  lb_listener_id = data.terraform_remote_state.cluster.outputs.lb_listener_id
+  lb_zone_id     = data.terraform_remote_state.cluster.outputs.lb_zone_id
+  vpc_id         = data.terraform_remote_state.vpc.outputs.vpc_id
+
+  cluster_remote_state_workspace        = "${local.environment}-cluster"
+  iam_remote_state_workspace            = "global-iam"
+  postgres_remote_state_workspace       = "${local.environment}-postgres"
+  postgres_setup_remote_state_workspace = "${local.environment}-postgres-setup"
+  remote_state_organization             = "debtcollective"
+  vpc_remote_state_workspace            = "${local.environment}-network"
+}

--- a/live/test/services/chatwoot/dependencies.tf
+++ b/live/test/services/chatwoot/dependencies.tf
@@ -67,7 +67,7 @@ data "aws_ssm_parameter" "db_pass" {
 }
 
 locals {
-  environment = "prod"
+  environment = "test"
 
   db_host             = data.terraform_remote_state.postgres.outputs.db_address
   db_name             = data.terraform_remote_state.postgres_setup.outputs.chatwoot_db_name

--- a/live/test/services/chatwoot/iam.tf
+++ b/live/test/services/chatwoot/iam.tf
@@ -1,6 +1,4 @@
 // User for Chatwoot s3 uploads
-data "aws_caller_identity" "current" {}
-
 resource "aws_iam_user" "chatwoot" {
   name = "chatwoot_uploads_${local.environment}"
   path = "/terraform/${local.environment}/chatwoot/"
@@ -14,11 +12,6 @@ resource "aws_iam_user" "chatwoot" {
 data "aws_iam_policy_document" "chatwoot" {
   statement {
     sid = "1"
-
-    principals {
-      type        = "AWS"
-      identifiers = [data.aws_caller_identity.current.arn]
-    }
 
     actions = [
       "s3:DeleteObject",

--- a/live/test/services/chatwoot/iam.tf
+++ b/live/test/services/chatwoot/iam.tf
@@ -1,0 +1,46 @@
+// User for Chatwoot s3 uploads
+data "aws_caller_identity" "current" {}
+
+resource "aws_iam_user" "chatwoot" {
+  name = "chatwoot_uploads_${local.environment}"
+  path = "/terraform/${local.environment}/chatwoot/"
+
+  tags = {
+    Terraform   = true
+    Environment = local.environment
+  }
+}
+
+data "aws_iam_policy_document" "chatwoot" {
+  statement {
+    sid = "1"
+
+    principals {
+      type        = "AWS"
+      identifiers = [data.aws_caller_identity.current.arn]
+    }
+
+    actions = [
+      "s3:DeleteObject",
+      "s3:GetObject",
+      "s3:ListBucket",
+      "s3:PutObject"
+    ]
+
+    resources = [
+      aws_s3_bucket.uploads.arn,
+      "${aws_s3_bucket.uploads.arn}/*",
+    ]
+  }
+}
+
+resource "aws_iam_user_policy" "user_policy" {
+  name_prefix = "ChatwootPolicy${title(local.environment)}"
+  user        = aws_iam_user.chatwoot.name
+
+  policy = data.aws_iam_policy_document.chatwoot.json
+}
+
+resource "aws_iam_access_key" "chatwoot" {
+  user = aws_iam_user.chatwoot.name
+}

--- a/live/test/services/chatwoot/main.tf
+++ b/live/test/services/chatwoot/main.tf
@@ -21,7 +21,7 @@ data "aws_route53_zone" "primary" {
 
 resource "aws_route53_record" "chatwoot" {
   zone_id = data.aws_route53_zone.primary.zone_id
-  name    = "chatwoot"
+  name    = "chatwoot-${local.environment}"
   type    = "A"
 
   alias {

--- a/live/test/services/chatwoot/main.tf
+++ b/live/test/services/chatwoot/main.tf
@@ -41,9 +41,23 @@ module "chatwoot" {
   vpc_id                       = local.vpc_id
   container_memory_reservation = 256
 
-  db_host     = local.db_host
-  db_name     = local.db_name
-  db_password = local.db_password
-  db_port     = local.db_port
-  db_username = local.db_username
+  frontend_url    = "https://${aws_route53_record.chatwoot.fqdn}"
+  database_url    = "postgres://${local.db_username}:${local.db_password}@${local.db_host}:${local.db_port}/${local.db_name}"
+  secret_key_base = var.secret_key_base
+
+  mailer_sender_email = var.mailer_sender_email
+  smtp_address        = var.smtp_address
+  smtp_username       = var.smtp_username
+  smtp_password       = var.smtp_password
+  smtp_domain         = var.smtp_domain
+
+  vapid_public_key  = var.vapid_public_key
+  vapid_private_key = var.vapid_private_key
+
+  s3_bucket_name        = aws_s3_bucket.uploads.id
+  aws_access_key_id     = aws_iam_access_key.chatwoot.id
+  aws_secret_access_key = aws_iam_access_key.chatwoot.secret
+  aws_region            = aws_s3_bucket.uploads.region
+
+  redis_url = local.redis_url
 }

--- a/live/test/services/chatwoot/main.tf
+++ b/live/test/services/chatwoot/main.tf
@@ -1,0 +1,49 @@
+terraform {
+  required_version = ">=0.12.20"
+
+  backend "remote" {
+    hostname     = "app.terraform.io"
+    organization = "debtcollective"
+
+    workspaces {
+      name = "test-services-chatwoot"
+    }
+  }
+}
+
+provider "aws" {
+  version = "~> 2.0"
+}
+
+data "aws_route53_zone" "primary" {
+  name = "debtcollective.org"
+}
+
+resource "aws_route53_record" "chatwoot" {
+  zone_id = data.aws_route53_zone.primary.zone_id
+  name    = "chatwoot"
+  type    = "A"
+
+  alias {
+    name                   = local.lb_dns_name
+    zone_id                = local.lb_zone_id
+    evaluate_target_health = false
+  }
+}
+
+module "chatwoot" {
+  source      = "../../../../modules/services/chatwoot"
+  environment = local.environment
+
+  domain                       = aws_route53_record.chatwoot.fqdn
+  ecs_cluster_id               = local.ecs_cluster_id
+  lb_listener_id               = local.lb_listener_id
+  vpc_id                       = local.vpc_id
+  container_memory_reservation = 256
+
+  db_host     = local.db_host
+  db_name     = local.db_name
+  db_password = local.db_password
+  db_port     = local.db_port
+  db_username = local.db_username
+}

--- a/live/test/services/chatwoot/outputs.tf
+++ b/live/test/services/chatwoot/outputs.tf
@@ -1,0 +1,4 @@
+output "service_name" {
+  value       = module.chatwoot.service_name
+  description = "ECS Service name"
+}

--- a/live/test/services/chatwoot/s3.tf
+++ b/live/test/services/chatwoot/s3.tf
@@ -1,0 +1,15 @@
+// S3 buckets and permissions
+resource "aws_s3_bucket" "uploads" {
+  bucket = local.uploads_bucket_name
+  acl    = "private"
+
+  lifecycle {
+    prevent_destroy = true
+  }
+
+  tags = {
+    Terraform   = true
+    Name        = local.uploads_bucket_name
+    Environment = local.environment
+  }
+}

--- a/live/test/services/chatwoot/vars.tf
+++ b/live/test/services/chatwoot/vars.tf
@@ -1,0 +1,49 @@
+/* ECS */
+/*
+ * Chatwoot env variables
+ */
+
+/* App */
+variable "secret_key_base" {
+  description = "Secret key for sessions"
+}
+
+variable "log_level" {
+  description = "Log level for the app"
+  default     = "info"
+}
+
+/* Email */
+variable "mailer_sender_email" {
+  description = "Email from"
+}
+
+variable "smtp_address" {
+  description = "SMTP address"
+}
+
+variable "smtp_username" {
+  description = "SMTP username"
+}
+
+variable "smtp_password" {
+  description = "SMTP password"
+}
+
+variable "smtp_domain" {
+  description = "SMTP domain"
+}
+
+variable "smtp_port" {
+  description = "SMTP port"
+  default     = "587"
+}
+
+/* Push notifications */
+variable "vapid_public_key" {
+  description = "VAPID public key"
+}
+
+variable "vapid_private_key" {
+  description = "VAPID private key"
+}

--- a/modules/data-stores/postgres/main.tf
+++ b/modules/data-stores/postgres/main.tf
@@ -70,7 +70,7 @@ resource "aws_db_instance" "pg" {
   identifier        = "postgres-${var.environment}"
   allocated_storage = var.allocated_storage
   engine            = "postgres"
-  engine_version    = "11.6"
+  engine_version    = var.engine_version
   instance_class    = var.instance_class
   name              = local.db_name
   username          = aws_ssm_parameter.master_user.value

--- a/modules/data-stores/postgres/vars.tf
+++ b/modules/data-stores/postgres/vars.tf
@@ -36,3 +36,8 @@ variable "vpc_security_group_ids" {
 variable "skip_final_snapshot" {
   default = false
 }
+
+variable "engine_version" {
+  description = "postgres engine version"
+  default     = "11.6"
+}

--- a/modules/services/chatwoot/container_definitions.tf
+++ b/modules/services/chatwoot/container_definitions.tf
@@ -154,7 +154,6 @@ module "container_definition_workers" {
   container_cpu                = null
   container_memory             = null
   container_memory_reservation = var.container_memory_reservation
-  essential                    = true
   container_image              = var.container_image
 
   environment = local.environment

--- a/modules/services/chatwoot/container_definitions.tf
+++ b/modules/services/chatwoot/container_definitions.tf
@@ -1,0 +1,140 @@
+resource "aws_cloudwatch_log_group" "chatwoot" {
+  name              = "/${var.environment}/services/chatwoot"
+  retention_in_days = var.log_retention_in_days
+
+  tags = {
+    Environment = var.environment
+    Application = "chatwoot"
+    Terraform   = true
+  }
+}
+
+module "container_definitions" {
+  source = "git::https://github.com/cloudposse/terraform-aws-ecs-container-definition.git?ref=0.47.0"
+
+  container_name               = local.container_name
+  container_cpu                = null
+  container_memory             = null
+  container_memory_reservation = var.container_memory_reservation
+  essential                    = true
+  container_image              = var.container_image
+
+  environment = [
+    /* Email */
+    {
+      name  = "MAILER_SENDER_EMAIL",
+      value = var.mailer_sender_email
+    },
+    {
+      name  = "SMTP_ADDRESS",
+      value = var.smtp_address
+    },
+    {
+      name  = "SMTP_USERNAME",
+      value = var.smtp_username
+    },
+    {
+      name  = "SMTP_PASSWORD",
+      value = var.smtp_password
+    },
+    {
+      name  = "SMTP_AUTHENTICATION",
+      value = "plain"
+    },
+    {
+      name  = "SMTP_DOMAIN",
+      value = var.smtp_domain
+    },
+    {
+      name  = "SMTP_ENABLE_STARTTLS_AUTO",
+      value = true
+    },
+    {
+      name  = "SMTP_PORT",
+      value = var.smtp_port
+    },
+
+    /* App */
+    {
+      name  = "FRONTEND_URL",
+      value = var.frontend_url
+    },
+    {
+      name  = "DEFAULT_LOCALE",
+      value = "en"
+    },
+    {
+      name  = "DATABASE_URL",
+      value = var.database_url
+    },
+    {
+      name  = "RAILS_ENV",
+      value = var.rails_env
+    },
+    {
+      name  = "SECRET_KEY_BASE",
+      value = var.secret_key_base
+    },
+    {
+      name  = "LOG_LEVEL",
+      value = var.log_level
+    },
+
+    /* Push notifications */
+    {
+      name  = "VAPID_PUBLIC_KEY",
+      value = var.vapid_public_key
+    },
+    {
+      name  = "VAPID_PRIVATE_KEY",
+      value = var.vapid_private_key
+    },
+
+    /* Storage, we use AWS S3 */
+    {
+      name  = "ACTIVE_STORAGE_SERVICE",
+      value = "amazon"
+    },
+    {
+      name  = "S3_BUCKET_NAME",
+      value = var.s3_bucket_name
+    },
+    {
+      name  = "AWS_ACCESS_KEY_ID",
+      value = var.aws_access_key_id
+    },
+    {
+      name  = "AWS_SECRET_ACCESS_KEY",
+      value = var.aws_secret_access_key
+    },
+    {
+      name  = "AWS_REGION",
+      value = var.aws_region
+    },
+
+    /* Redis */
+    {
+      name  = "REDIS_URL",
+      value = var.redis_url
+    },
+
+    /* Channels */
+  ]
+
+  port_mappings = [
+    {
+      containerPort = local.container_port
+      hostPort      = null
+      protocol      = "tcp"
+    }
+  ]
+
+  log_configuration = {
+    logDriver = "awslogs"
+    options = {
+      "awslogs-region" = data.aws_region.current.name
+      "awslogs-group"  = aws_cloudwatch_log_group.chatwoot.name
+    }
+    secretOptions = null
+  }
+}

--- a/modules/services/chatwoot/container_definitions.tf
+++ b/modules/services/chatwoot/container_definitions.tf
@@ -10,7 +10,7 @@ resource "aws_cloudwatch_log_group" "chatwoot" {
 }
 
 module "container_definitions" {
-  source = "git::https://github.com/cloudposse/terraform-aws-ecs-container-definition.git?ref=0.47.0"
+  source = "git::https://github.com/cloudposse/terraform-aws-ecs-container-definition.git?ref=0.23.0"
 
   container_name               = local.container_name
   container_cpu                = null
@@ -61,7 +61,7 @@ module "container_definitions" {
     },
     {
       name  = "DEFAULT_LOCALE",
-      value = "en"
+      value = var.default_locale
     },
     {
       name  = "DATABASE_URL",

--- a/modules/services/chatwoot/container_definitions.tf
+++ b/modules/services/chatwoot/container_definitions.tf
@@ -150,7 +150,7 @@ module "container_definition_app" {
 module "container_definition_workers" {
   source = "git::https://github.com/cloudposse/terraform-aws-ecs-container-definition.git?ref=0.23.0"
 
-  container_name               = local.container_name
+  container_name               = "${local.container_name}-workers"
   container_cpu                = null
   container_memory             = null
   container_memory_reservation = var.container_memory_reservation

--- a/modules/services/chatwoot/main.tf
+++ b/modules/services/chatwoot/main.tf
@@ -14,6 +14,13 @@ resource "aws_lb_target_group" "chatwoot" {
   protocol    = "HTTP"
   vpc_id      = var.vpc_id
 
+  health_check {
+    interval = 120
+    timeout  = 60
+    matcher  = "200-299"
+    path     = "/"
+  }
+
   lifecycle {
     create_before_destroy = true
   }
@@ -37,7 +44,7 @@ resource "aws_lb_listener_rule" "chatwoot" {
 // Create ECS task definition
 resource "aws_ecs_task_definition" "chatwoot" {
   family                = "chatwoot_${var.environment}"
-  container_definitions = module.container_definitions.json
+  container_definitions = "[${module.container_definition_app.json_map},${module.container_definition_workers.json_map}]"
 }
 
 // Create ECS service

--- a/modules/services/chatwoot/main.tf
+++ b/modules/services/chatwoot/main.tf
@@ -1,0 +1,55 @@
+locals {
+  container_name = "chatwoot"
+  container_port = 3000
+  name_prefix    = "cw-${substr(var.environment, 0, 2)}-"
+
+}
+
+data "aws_region" "current" {}
+
+// Load balancer
+resource "aws_lb_target_group" "chatwoot" {
+  name_prefix = local.name_prefix
+  port        = 80
+  protocol    = "HTTP"
+  vpc_id      = var.vpc_id
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+// Services only should define this to work correctly
+resource "aws_lb_listener_rule" "chatwoot" {
+  listener_arn = var.lb_listener_id
+
+  action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.chatwoot.arn
+  }
+
+  condition {
+    field  = "host-header"
+    values = [var.domain]
+  }
+}
+
+// Create ECS task definition
+resource "aws_ecs_task_definition" "chatwoot" {
+  family                = "chatwoot_${var.environment}"
+  container_definitions = module.container_definitions.json
+}
+
+// Create ECS service
+resource "aws_ecs_service" "chatwoot" {
+  name            = "chatwoot"
+  cluster         = var.ecs_cluster_id
+  task_definition = aws_ecs_task_definition.chatwoot.arn
+  desired_count   = var.desired_count
+
+  load_balancer {
+    target_group_arn = aws_lb_target_group.chatwoot.arn
+    container_name   = local.container_name
+    container_port   = local.container_port
+  }
+}

--- a/modules/services/chatwoot/main.tf
+++ b/modules/services/chatwoot/main.tf
@@ -17,7 +17,7 @@ resource "aws_lb_target_group" "chatwoot" {
   health_check {
     interval = 120
     timeout  = 60
-    matcher  = "200-299"
+    matcher  = "200"
     path     = "/"
   }
 

--- a/modules/services/chatwoot/outputs.tf
+++ b/modules/services/chatwoot/outputs.tf
@@ -1,0 +1,4 @@
+output "service_name" {
+  value       = aws_ecs_service.chatwoot.name
+  description = "ECS Service name"
+}

--- a/modules/services/chatwoot/vars.tf
+++ b/modules/services/chatwoot/vars.tf
@@ -1,0 +1,147 @@
+
+/* ECS */
+variable "environment" {
+  description = "Environment name"
+}
+
+variable "container_image" {
+  description = "Docker image name"
+  default     = "chatwoot/chatwoot:latest"
+}
+
+variable "container_memory_reservation" {
+  description = "Memory reservation for containers"
+  default     = 1024
+}
+
+variable "vpc_id" {
+  description = "VPC Id to be used by the LB"
+}
+
+variable "lb_listener_id" {
+  description = "LB listener id"
+}
+
+variable "ecs_cluster_id" {
+  description = "ECS cluster id where the app will run"
+}
+
+variable "domain" {
+  description = "FQDN where app will be available"
+}
+
+variable "desired_count" {
+  description = "Number of instances to be run"
+  default     = 1
+}
+
+variable "log_retention_in_days" {
+  description = "Cloudwatch logs retention"
+  default     = 3
+}
+
+variable "domain" {
+  description = "Domain name"
+}
+
+/*
+ * Chatwoot env variables
+ */
+
+/* App */
+variable "frontend_url" {
+  description = "Front-end full URL"
+  default     = var.domain
+}
+
+variable "default_locale" {
+  description = "Default locale"
+  default     = "en"
+}
+
+variable "database_url" {
+  description = "Postgres schema URL"
+}
+
+variable "rails_env" {
+  description = "Rails environment"
+  default     = "production"
+}
+
+variable "secret_key_base" {
+  description = "Secret key for sessions"
+}
+
+variable "log_level" {
+  description = "Log level for the app"
+  default     = "info"
+}
+
+/* Email */
+variable "mailer_sender_email" {
+  description = "Email from"
+}
+
+variable "smtp_address" {
+  description = "SMTP address"
+}
+
+variable "smtp_username" {
+  description = "SMTP username"
+}
+
+variable "smtp_password" {
+  description = "SMTP password"
+}
+
+variable "smtp_authentication" {
+  description = "SMTP authentication mode"
+  default     = "plain"
+}
+
+variable "smtp_domain" {
+  description = "SMTP domain"
+}
+
+variable "smtp_enable_starttls_auto" {
+  description = "SMTP TLS"
+  default     = true
+}
+
+variable "smtp_port" {
+  description = "SMTP port"
+  default     = "587"
+}
+
+/* Push notifications */
+variable "vapid_public_key" {
+  description = "VAPID public key"
+}
+
+variable "vapid_private_key" {
+  description = "VAPID private key"
+}
+
+/* Storage, we use AWS S3 */
+variable "s3_bucket_name" {
+  description = "AWS S3 bucket name"
+}
+
+variable "aws_access_key_id" {
+  description = "AWS S3 access key id"
+}
+
+variable "aws_secret_access_key" {
+  description = "AWS S3 secret access key"
+}
+
+variable "aws_region" {
+  description = "AWS S3 region"
+}
+
+/* Redis */
+variable "redis_url" {
+  description = "Redis URL in redis uri scheme"
+}
+
+/* Channels */

--- a/modules/services/chatwoot/vars.tf
+++ b/modules/services/chatwoot/vars.tf
@@ -1,4 +1,3 @@
-
 /* ECS */
 variable "environment" {
   description = "Environment name"

--- a/modules/services/chatwoot/vars.tf
+++ b/modules/services/chatwoot/vars.tf
@@ -11,7 +11,7 @@ variable "container_image" {
 
 variable "container_memory_reservation" {
   description = "Memory reservation for containers"
-  default     = 1024
+  default     = 512
 }
 
 variable "vpc_id" {
@@ -40,10 +40,6 @@ variable "log_retention_in_days" {
   default     = 3
 }
 
-variable "domain" {
-  description = "Domain name"
-}
-
 /*
  * Chatwoot env variables
  */
@@ -51,7 +47,6 @@ variable "domain" {
 /* App */
 variable "frontend_url" {
   description = "Front-end full URL"
-  default     = var.domain
 }
 
 variable "default_locale" {


### PR DESCRIPTION
**What:** Add chatwoot to our infra

**Why:** Closes https://app.asana.com/0/1168997577035609/1199650841826384

**How:**

- Create chatwoot module, along all the resources it needs to run
- Configure Terraform cloud variables to deploy chatwoot

**Notes:**
There's an issue with database migrations not running correctly, I created a ticket for this on the chatwoot repo https://github.com/chatwoot/chatwoot/issues/1702. I hope we get an answer ASAP but I'll look into workarounds to make it work if that doesn't happen.