### PR TITLE
fix: update health check redirect

### DIFF
--- a/modules/services/docassemble/main.tf
+++ b/modules/services/docassemble/main.tf
@@ -22,10 +22,12 @@ resource "aws_lb_target_group" "docassemble" {
   vpc_id      = var.vpc_id
 
   health_check {
-    interval = 120
-    timeout  = 60
-    matcher  = "200"
-    path     = "/"
+    interval            = 300
+    matcher             = "200-299,300-399"
+    path                = "/"
+    timeout             = 120
+    healthy_threshold   = 2
+    unhealthy_threshold = 5
   }
 
 

--- a/modules/services/docassemble/vars.tf
+++ b/modules/services/docassemble/vars.tf
@@ -9,7 +9,7 @@ variable "container_image" {
 
 variable "container_memory_reservation" {
   description = "Memory reservation for containers"
-  default     = 2048
+  default     = 1963
 }
 variable "container_cpu" {
   description = "Container CPUs to allocate"


### PR DESCRIPTION
**What:** Allow any 200, 300 status codes for ELB Health Check

**Why:** Health Check was redirecting a 302 status instead of 200 which caused instance to be deemed unhealthy